### PR TITLE
feat: 인증/인가 관련 전역 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,14 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // OAuth2 Resource Server
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
+
+    // JWT 라이브러리 (jjwt)
+    implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/indiv/abko/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/indiv/abko/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+	AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/indiv/abko/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/indiv/abko/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -1,0 +1,16 @@
+package indiv.abko.taskflow.domain.auth.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indiv.abko.taskflow.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/indiv/abko/taskflow/global/auth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/indiv/abko/taskflow/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,25 @@
+package indiv.abko.taskflow.global.auth;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+	private final HandlerExceptionResolver resolver;
+
+	public CustomAuthenticationEntryPoint(@Qualifier("handlerExceptionResolver") HandlerExceptionResolver resolver) {
+		this.resolver = resolver;
+	}
+
+	@Override
+	public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) {
+		resolver.resolveException(request, response, null, authException);
+	}
+}

--- a/src/main/java/indiv/abko/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/indiv/abko/taskflow/global/config/SecurityConfig.java
@@ -1,0 +1,59 @@
+package indiv.abko.taskflow.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+import indiv.abko.taskflow.domain.auth.exception.AuthErrorCode;
+import indiv.abko.taskflow.global.exception.BusinessException;
+import indiv.abko.taskflow.global.jwt.JwtAuthenticationConverter;
+import indiv.abko.taskflow.global.jwt.JwtUtil;
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+	private final JwtUtil jwtUtil;
+	private final JwtAuthenticationConverter jwtAuthenticationConverter;
+
+	@Bean
+	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+		http
+			.csrf(AbstractHttpConfigurer::disable)
+			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+			.authorizeHttpRequests(auth -> auth
+				.requestMatchers("/api/auth/**").permitAll()
+				.anyRequest().authenticated()
+			)
+			.oauth2ResourceServer(oauth2 -> oauth2
+				.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
+			);
+
+		return http.build();
+	}
+
+	@Bean
+	public JwtDecoder jwtDecoder() {
+		return token -> {
+			if (!jwtUtil.validateToken(token)) {
+				throw new BusinessException(AuthErrorCode.INVALID_TOKEN);
+			}
+			return jwtUtil.getJwt(token);
+		};
+	}
+
+	@Bean
+	public PasswordEncoder passwordEncoder() {
+		return new BCryptPasswordEncoder();
+	}
+
+}

--- a/src/main/java/indiv/abko/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/indiv/abko/taskflow/global/config/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.oauth2.jwt.JwtDecoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import indiv.abko.taskflow.domain.auth.exception.AuthErrorCode;
+import indiv.abko.taskflow.global.auth.CustomAuthenticationEntryPoint;
 import indiv.abko.taskflow.global.exception.BusinessException;
 import indiv.abko.taskflow.global.jwt.JwtAuthenticationConverter;
 import indiv.abko.taskflow.global.jwt.JwtUtil;
@@ -24,6 +25,7 @@ public class SecurityConfig {
 
 	private final JwtUtil jwtUtil;
 	private final JwtAuthenticationConverter jwtAuthenticationConverter;
+	private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
 	@Bean
 	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -36,7 +38,8 @@ public class SecurityConfig {
 			)
 			.oauth2ResourceServer(oauth2 -> oauth2
 				.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
-			);
+			)
+			.exceptionHandling(handler -> handler.authenticationEntryPoint(customAuthenticationEntryPoint));
 
 		return http.build();
 	}

--- a/src/main/java/indiv/abko/taskflow/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/indiv/abko/taskflow/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
+import indiv.abko.taskflow.domain.auth.exception.AuthErrorCode;
 import indiv.abko.taskflow.global.dto.CommonResponse;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,21 @@ public class GlobalExceptionHandler {
 	public ResponseEntity<CommonResponse<?>> handleBusinessException(BusinessException ex) {
 		CommonResponse<?> response = CommonResponse.failure(ex.getMessage(), null);
 		HttpStatus status = ex.getErrorCode().getHttpStatus();
+
+		return new ResponseEntity<>(response, status);
+	}
+
+	@ExceptionHandler(AuthenticationException.class)
+	public ResponseEntity<CommonResponse<?>> handleAuthenticationException(AuthenticationException ex) {
+		ErrorCode errorCode;
+		if (ex.getCause() instanceof BusinessException businessException) {
+			errorCode = businessException.getErrorCode();
+		} else {
+			errorCode = AuthErrorCode.AUTHENTICATION_FAILED;
+		}
+
+		CommonResponse<?> response = CommonResponse.failure(errorCode.getMessage(), null);
+		HttpStatus status = errorCode.getHttpStatus();
 
 		return new ResponseEntity<>(response, status);
 	}

--- a/src/main/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverter.java
@@ -1,0 +1,30 @@
+package indiv.abko.taskflow.global.jwt;
+
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.global.auth.AuthMember;
+import java.util.Collection;
+import java.util.Collections;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticationToken> {
+
+    private static final String AUTHORITIES_KEY = "auth";
+
+    @Override
+    public JwtAuthenticationToken convert(Jwt jwt) {
+        long memberId = Long.parseLong(jwt.getSubject());
+        UserRole userRole = UserRole.valueOf(jwt.getClaimAsString(AUTHORITIES_KEY));
+
+        AuthMember authMember = new AuthMember(memberId, userRole);
+
+        Collection<? extends GrantedAuthority> authorities =
+                Collections.singletonList(new SimpleGrantedAuthority(userRole.getKey()));
+
+        return new JwtAuthenticationToken(authMember, jwt, authorities);
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,29 @@
+package indiv.abko.taskflow.global.jwt;
+
+import indiv.abko.taskflow.global.auth.AuthMember;
+import java.util.Collection;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
+import org.springframework.security.core.GrantedAuthority;
+
+public class JwtAuthenticationToken extends AbstractAuthenticationToken {
+
+    private final AuthMember principal;
+    private final Object credentials;
+
+    public JwtAuthenticationToken(AuthMember principal, Object credentials, Collection<? extends GrantedAuthority> authorities) {
+        super(authorities);
+        this.principal = principal;
+        this.credentials = credentials;
+        setAuthenticated(true);
+    }
+
+    @Override
+    public Object getCredentials() {
+        return credentials;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return principal;
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/global/jwt/JwtUtil.java
+++ b/src/main/java/indiv/abko/taskflow/global/jwt/JwtUtil.java
@@ -1,0 +1,96 @@
+package indiv.abko.taskflow.global.jwt;
+
+import java.security.Key;
+import java.time.Instant;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+
+import indiv.abko.taskflow.global.auth.AuthMember;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+public class JwtUtil {
+
+	private static final String AUTHORITIES_KEY = "auth";
+	private final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+	@Value("${jwt.secret}")
+	private String secretKey;
+	@Value("${jwt.access-token-validity-seconds}")
+	private long accessTokenValiditySeconds;
+	private Key key;
+
+	@PostConstruct
+	public void init() {
+		this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+	}
+
+	public String createAccessToken(AuthMember authMember) {
+		long now = (new Date()).getTime();
+		Date validity = new Date(now + this.accessTokenValiditySeconds * 1000);
+
+		return Jwts.builder()
+			.setSubject(String.valueOf(authMember.memberId()))
+			.claim(AUTHORITIES_KEY, authMember.userRole().name())
+			.setIssuedAt(new Date(now))
+			.signWith(key, signatureAlgorithm)
+			.setExpiration(validity)
+			.compact();
+	}
+
+	public boolean validateToken(String token) {
+		try {
+			Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token);
+
+			return true;
+		} catch (SecurityException | MalformedJwtException e) {
+			log.info("잘못된 JWT 서명입니다.");
+		} catch (ExpiredJwtException e) {
+			log.info("만료된 JWT 토큰입니다.");
+		} catch (UnsupportedJwtException e) {
+			log.info("지원되지 않는 JWT 토큰입니다.");
+		} catch (IllegalArgumentException e) {
+			log.info("JWT 토큰이 잘못되었습니다.");
+		}
+
+		return false;
+	}
+
+	public Jwt getJwt(String token) {
+		Claims claims = parseClaims(token);
+		Instant issuedAt = claims.getIssuedAt().toInstant();
+		Instant expiresAt = claims.getExpiration().toInstant();
+
+		return Jwt.withTokenValue(token)
+			.header("alg", signatureAlgorithm.getValue())
+			.subject(claims.getSubject())
+			.claims(c -> c.putAll(claims))
+			.issuedAt(issuedAt)
+			.expiresAt(expiresAt)
+			.build();
+	}
+
+	private Claims parseClaims(String token) {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+			.getBody();
+	}
+
+}

--- a/src/test/java/indiv/abko/taskflow/global/auth/CustomAuthenticationEntryPointTest.java
+++ b/src/test/java/indiv/abko/taskflow/global/auth/CustomAuthenticationEntryPointTest.java
@@ -1,0 +1,51 @@
+package indiv.abko.taskflow.global.auth;
+
+import static org.mockito.Mockito.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class CustomAuthenticationEntryPointTest {
+
+	private CustomAuthenticationEntryPoint entryPoint;
+
+	@Mock
+	private HandlerExceptionResolver mockResolver;
+
+	@Mock
+	private HttpServletRequest request;
+
+	@Mock
+	private HttpServletResponse response;
+
+	@Mock
+	private AuthenticationException authException;
+
+	@BeforeEach
+	void setUp() {
+		// 실제 리졸버 대신 Mock 리졸버를 주입합니다.
+		entryPoint = new CustomAuthenticationEntryPoint(mockResolver);
+	}
+
+	@Test
+	@DisplayName("commence가 호출되면, HandlerExceptionResolver에게 예외 처리를 위임한다")
+	void commence() {
+		// when
+		entryPoint.commence(request, response, authException);
+
+		// then
+		// resolver의 resolveException이 정확한 인자들로 호출되었는지 검증합니다.
+		verify(mockResolver).resolveException(request, response, null, authException);
+	}
+}
+

--- a/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverterUnitTest.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverterUnitTest.java
@@ -1,0 +1,50 @@
+package indiv.abko.taskflow.global.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.Instant;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.global.auth.AuthMember;
+
+class JwtAuthenticationConverterUnitTest {
+
+	private final JwtAuthenticationConverter converter = new JwtAuthenticationConverter();
+
+	@Test
+	@DisplayName("Jwt 객체를 JwtAuthenticationToken으로 변환한다")
+	void convert() {
+		// given
+		long memberId = 1L;
+		UserRole userRole = UserRole.USER;
+		String tokenValue = "test-token";
+
+		Jwt jwt = Jwt.withTokenValue(tokenValue)
+			.header("alg", "HS256")
+			.subject(String.valueOf(memberId))
+			.claim("auth", userRole.name())
+			.issuedAt(Instant.now())
+			.expiresAt(Instant.now().plusSeconds(60))
+			.build();
+
+		// when
+		JwtAuthenticationToken authentication = converter.convert(jwt);
+
+		// then
+		assertThat(authentication).isNotNull();
+		assertThat(authentication.getPrincipal()).isInstanceOf(AuthMember.class);
+
+		AuthMember authMember = (AuthMember)authentication.getPrincipal();
+		assertThat(authMember.memberId()).isEqualTo(memberId);
+		assertThat(authMember.userRole()).isEqualTo(userRole);
+
+		assertThat(authentication.getAuthorities()).hasSize(1);
+		GrantedAuthority authority = authentication.getAuthorities().iterator().next();
+		assertThat(authority.getAuthority()).isEqualTo(userRole.getKey());
+	}
+}

--- a/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationTokenUnitTest.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationTokenUnitTest.java
@@ -1,0 +1,35 @@
+package indiv.abko.taskflow.global.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.global.auth.AuthMember;
+
+class JwtAuthenticationTokenUnitTest {
+
+	@Test
+	@DisplayName("JwtAuthenticationToken 생성 시 principal, credentials, authorities가 올바르게 설정되고 인증 상태가 true가 된다")
+	void createToken() {
+		// given
+		AuthMember principal = new AuthMember(1L, UserRole.USER);
+		String credentials = "jwt-token-string";
+		Collection<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(UserRole.USER.getKey()));
+
+		// when
+		JwtAuthenticationToken token = new JwtAuthenticationToken(principal, credentials, authorities);
+
+		// then
+		assertThat(token.getPrincipal()).isEqualTo(principal);
+		assertThat(token.getCredentials()).isEqualTo(credentials);
+		assertThat(token.getAuthorities()).isEqualTo(authorities);
+		assertThat(token.isAuthenticated()).isTrue();
+	}
+}

--- a/src/test/java/indiv/abko/taskflow/global/jwt/JwtUtilUnitTest.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/JwtUtilUnitTest.java
@@ -1,0 +1,123 @@
+package indiv.abko.taskflow.global.jwt;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.Instant;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.global.auth.AuthMember;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@ExtendWith(MockitoExtension.class)
+class JwtUtilUnitTest {
+
+	private final String TEST_SECRET_KEY = "testtesttesttesttesttesttesttesttesttest";
+	private final long TEST_ACCESS_TOKEN_VALIDITY_SECONDS = 3600;
+	private JwtUtil jwtUtil;
+
+	@BeforeEach
+	void setUp() {
+		jwtUtil = new JwtUtil();
+		ReflectionTestUtils.setField(jwtUtil, "secretKey", TEST_SECRET_KEY);
+		ReflectionTestUtils.setField(jwtUtil, "accessTokenValiditySeconds", TEST_ACCESS_TOKEN_VALIDITY_SECONDS);
+		jwtUtil.init();
+	}
+
+	@Test
+	@DisplayName("AuthMember 정보를 담은 액세스 토큰을 생성한다")
+	void createAccessToken() {
+		// given
+		AuthMember authMember = new AuthMember(1L, UserRole.USER);
+
+		// when
+		String accessToken = jwtUtil.createAccessToken(authMember);
+
+		// then
+		assertThat(accessToken).isNotNull();
+		assertThat(jwtUtil.validateToken(accessToken)).isTrue();
+	}
+
+	@Test
+	@DisplayName("유효한 토큰을 검증하면 true를 반환한다")
+	void validateToken_success() {
+		// given
+		AuthMember authMember = new AuthMember(1L, UserRole.USER);
+		String accessToken = jwtUtil.createAccessToken(authMember);
+
+		// when
+		boolean isValid = jwtUtil.validateToken(accessToken);
+
+		// then
+		assertThat(isValid).isTrue();
+	}
+
+	@Test
+	@DisplayName("만료된 토큰을 검증하면 false를 반환한다")
+	void validateToken_expired() {
+		// given
+		AuthMember authMember = new AuthMember(1L, UserRole.USER);
+		// 유효시간을 음수값으로 주어 만료된 토큰을 생성
+		String accessToken = TestJwtUtil.createAccessToken(authMember, -1, TEST_SECRET_KEY);
+
+		// when
+		boolean isValid = jwtUtil.validateToken(accessToken);
+
+		// then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	@DisplayName("잘못된 서명을 가진 토큰을 검증하면 false를 반환한다")
+	void validateToken_invalidSignature() {
+		// given
+		AuthMember authMember = new AuthMember(1L, UserRole.USER);
+		String validAccessToken = jwtUtil.createAccessToken(authMember);
+
+		// when
+		// 유효하지 않은 시크릿 키로 토큰을 다시 생성하여 서명을 조작
+		String invalidSecretKey = "invalidinvalidinvalidinvalidinvalidinvalid";
+		String tamperedToken = Jwts.builder()
+			.setSubject(String.valueOf(authMember.memberId()))
+			.claim("auth", authMember.userRole().name())
+			.setIssuedAt(new Date())
+			.signWith(Keys.hmacShaKeyFor(invalidSecretKey.getBytes()), SignatureAlgorithm.HS256)
+			.setExpiration(Date.from(Instant.now().plusSeconds(TEST_ACCESS_TOKEN_VALIDITY_SECONDS)))
+			.compact();
+
+		boolean isValid = jwtUtil.validateToken(tamperedToken);
+
+		// then
+		assertThat(isValid).isFalse();
+	}
+
+	@Test
+	@DisplayName("토큰 문자열을 Jwt 객체로 변환한다")
+	void getJwt() {
+		// given
+		long memberId = 1L;
+		UserRole userRole = UserRole.USER;
+		AuthMember authMember = new AuthMember(memberId, userRole);
+		String accessToken = jwtUtil.createAccessToken(authMember);
+
+		// when
+		Jwt jwt = jwtUtil.getJwt(accessToken);
+
+		// then
+		assertThat(jwt.getSubject()).isEqualTo(String.valueOf(memberId));
+		assertThat(jwt.getClaimAsString("auth")).isEqualTo(userRole.name());
+		assertDoesNotThrow(jwt::getIssuedAt);
+		assertDoesNotThrow(jwt::getExpiresAt);
+	}
+}

--- a/src/test/java/indiv/abko/taskflow/global/jwt/TestJwtUtil.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/TestJwtUtil.java
@@ -1,0 +1,29 @@
+package indiv.abko.taskflow.global.jwt;
+
+import indiv.abko.taskflow.global.auth.AuthMember;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+import java.security.Key;
+import java.util.Date;
+
+public class TestJwtUtil {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+
+    public static String createAccessToken(AuthMember authMember, long validitySeconds, String secretKey) {
+        long now = (new Date()).getTime();
+        Date validity = new Date(now + validitySeconds * 1000);
+        Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
+
+        return Jwts.builder()
+                .setSubject(String.valueOf(authMember.memberId()))
+                .claim(AUTHORITIES_KEY, authMember.userRole().name())
+                .setIssuedAt(new Date(now))
+                .signWith(key, signatureAlgorithm)
+                .setExpiration(validity)
+                .compact();
+    }
+}


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- spring security + OAuth2 resource server + JWT 를 사용한 인증/인가 전역 설정
- related to #27 
- close #32 

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- 인증/인가 전역 설정
- 단위테스트 작성

## 📌 필독
`dev` 브랜치 최신화 해주시고 `application-dev.yml` 파일에 아래 내용 추가 해주세요.
```yml
jwt:
  issuer: taskflow
  secret: bb9a2e7aef0725f694c36c67258300c193cf3089a767530d3220253c100b7394
  access-token-validity-seconds: 3600
```

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->