### PR TITLE
feat: 삭제되지 않은 모든 사용자의 목록을 조회하는 기능 구현

### DIFF
--- a/src/main/java/indiv/abko/taskflow/domain/user/controller/MemberController.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/controller/MemberController.java
@@ -1,12 +1,16 @@
 package indiv.abko.taskflow.domain.user.controller;
 
+import java.util.List;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import indiv.abko.taskflow.domain.user.dto.MemberInfoResponse;
+import indiv.abko.taskflow.domain.user.dto.MembersInfoResponse;
 import indiv.abko.taskflow.domain.user.service.ViewMemberInfoUseCase;
+import indiv.abko.taskflow.domain.user.service.ViewMembersInfoUseCase;
 import indiv.abko.taskflow.global.auth.AuthMember;
 import indiv.abko.taskflow.global.dto.CommonResponse;
 import lombok.RequiredArgsConstructor;
@@ -16,10 +20,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class MemberController {
 	private final ViewMemberInfoUseCase viewMemberInfoUseCase;
+	private final ViewMembersInfoUseCase viewMembersInfoUseCase;
 
 	@GetMapping("/me")
-	public CommonResponse<MemberInfoResponse> getMemberInfo(
+	public CommonResponse<MemberInfoResponse> getMember(
 		@AuthenticationPrincipal AuthMember authMember) {
 		return CommonResponse.success("사용자 정보를 조회했습니다.", viewMemberInfoUseCase.execute(authMember.memberId()));
+	}
+
+	@GetMapping("/")
+	public CommonResponse<List<MembersInfoResponse>> getAllMembers() {
+		return CommonResponse.success("요청이 성공적으로 처리되었습니다.", viewMembersInfoUseCase.execute());
 	}
 }

--- a/src/main/java/indiv/abko/taskflow/domain/user/dto/MembersInfoResponse.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/dto/MembersInfoResponse.java
@@ -1,0 +1,4 @@
+package indiv.abko.taskflow.domain.user.dto;
+
+public record MembersInfoResponse(Long id, String email, String name, String role) {
+}

--- a/src/main/java/indiv/abko/taskflow/domain/user/entity/Member.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/entity/Member.java
@@ -2,6 +2,8 @@ package indiv.abko.taskflow.domain.user.entity;
 
 import java.time.LocalDateTime;
 
+import org.hibernate.annotations.SQLRestriction;
+
 import indiv.abko.taskflow.global.entity.BaseTimeEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -21,6 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at IS NULL")
 public class Member extends BaseTimeEntity {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/indiv/abko/taskflow/domain/user/service/ViewMembersInfoUseCase.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/service/ViewMembersInfoUseCase.java
@@ -1,0 +1,25 @@
+package indiv.abko.taskflow.domain.user.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import indiv.abko.taskflow.domain.user.dto.MembersInfoResponse;
+import indiv.abko.taskflow.domain.user.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ViewMembersInfoUseCase {
+	private final MemberRepository memberRepository;
+
+	@Transactional(readOnly = true)
+	public List<MembersInfoResponse> execute() {
+		return memberRepository.findAll()
+			.stream()
+			.map(member -> new MembersInfoResponse(member.getId(), member.getEmail(),
+				member.getName(), member.getUserRole().name()))
+			.toList();
+	}
+}

--- a/src/test/java/indiv/abko/taskflow/domain/user/controller/MemberControllerTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/user/controller/MemberControllerTest.java
@@ -4,6 +4,8 @@ import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,12 +13,15 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 
 import indiv.abko.taskflow.domain.user.dto.MemberInfoResponse;
+import indiv.abko.taskflow.domain.user.dto.MembersInfoResponse;
 import indiv.abko.taskflow.domain.user.entity.Member;
 import indiv.abko.taskflow.domain.user.entity.UserRole;
 import indiv.abko.taskflow.domain.user.service.ViewMemberInfoUseCase;
+import indiv.abko.taskflow.domain.user.service.ViewMembersInfoUseCase;
 import indiv.abko.taskflow.global.auth.WithMockAuthMember;
 
 @WebMvcTest(controllers = MemberController.class)
@@ -27,6 +32,9 @@ public class MemberControllerTest {
 	@MockitoBean
 	ViewMemberInfoUseCase viewMemberInfoUseCase;
 
+	@MockitoBean
+	ViewMembersInfoUseCase viewMembersInfoUseCase;
+
 	@MockitoBean(name = "jpaMappingContext")
 	JpaMetamodelMappingContext jpaMetamodelMappingContext;
 
@@ -36,11 +44,10 @@ public class MemberControllerTest {
 	@Test
 	@WithMockAuthMember(memberId = 1L, userRole = UserRole.USER)
 	@DisplayName("GET /api/users/me - 인증된 사용자의 정보를 반환한다")
-	public void getMemberInfo_성공() throws Exception {
+	public void getMember_성공() throws Exception {
 		//given
 		Long memberId = 1L;
-		Member member = Member.of("testusername", "HASHED_PW", "test@example.com", "testname",
-			UserRole.USER);
+		Member member = Member.of("testusername", "HASHED_PW", "test@example.com", "testname", UserRole.USER);
 
 		var dto = new MemberInfoResponse(member.getId(), member.getUsername(), member.getEmail(), member.getName(),
 			member.getUserRole().name(), member.getCreatedAt());
@@ -61,4 +68,44 @@ public class MemberControllerTest {
 
 		verify(viewMemberInfoUseCase, times(1)).execute(memberId);
 	}
+
+	@Test
+	@WithMockAuthMember(memberId = 1L, userRole = UserRole.USER)
+	@DisplayName("GET /api/users/ - 모든 사용자의 정보를 반환한다")
+	public void getMembers_성공() throws Exception {
+		//given
+		Member member1 = Member.of("testusername", "HASHED_PW", "test@example.com", "testname", UserRole.USER);
+		Member member2 = Member.of("testusername2", "HASHED_PW2", "test2@example.com", "testname2", UserRole.ADMIN);
+		ReflectionTestUtils.setField(member1, "id", 1L);
+		ReflectionTestUtils.setField(member2, "id", 2L);
+
+		var dtoList = List.of(new MembersInfoResponse(member1.getId(), member1.getEmail(), member1.getName(),
+				member1.getUserRole().name()),
+			new MembersInfoResponse(member2.getId(), member2.getEmail(), member2.getName(),
+				member2.getUserRole().name()));
+		given(viewMembersInfoUseCase.execute()).willReturn(dtoList);
+
+		//when & then
+		mockMvc.perform(get("/api/users/"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.message").value("요청이 성공적으로 처리되었습니다."))
+			.andExpect(jsonPath("$.data").isArray())
+			.andExpect(jsonPath("$.data.length()").value(2))
+
+			.andExpect(jsonPath("$.data[0].id").value(1))
+			.andExpect(jsonPath("$.data[0].email").value("test@example.com"))
+			.andExpect(jsonPath("$.data[0].name").value("testname"))
+			.andExpect(jsonPath("$.data[0].role").value("USER"))
+
+			.andExpect(jsonPath("$.data[1].id").value(2))
+			.andExpect(jsonPath("$.data[1].email").value("test2@example.com"))
+			.andExpect(jsonPath("$.data[1].name").value("testname2"))
+			.andExpect(jsonPath("$.data[1].role").value("ADMIN"))
+
+			.andExpect(jsonPath("$.timestamp").exists());
+
+		verify(viewMembersInfoUseCase, times(1)).execute();
+	}
+
 }

--- a/src/test/java/indiv/abko/taskflow/domain/user/service/ViewMembersInfoUseCaseTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/user/service/ViewMembersInfoUseCaseTest.java
@@ -1,0 +1,70 @@
+package indiv.abko.taskflow.domain.user.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import indiv.abko.taskflow.domain.user.dto.MembersInfoResponse;
+import indiv.abko.taskflow.domain.user.entity.Member;
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.domain.user.repository.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+public class ViewMembersInfoUseCaseTest {
+	@Mock
+	private MemberRepository memberRepository;
+
+	@InjectMocks
+	private ViewMembersInfoUseCase viewMembersInfoUseCase;
+
+	@Test
+	@DisplayName("멤버 목록을 정상적으로 조회한다")
+	public void viewMembersInfoUseCase_성공() {
+		//given
+		Member member1 = Member.of("testusername", "HASHED_PW", "test@example.com", "testname", UserRole.USER);
+		ReflectionTestUtils.setField(member1, "id", 1L);
+		Member member2 = Member.of("testusername2", "HASHED_PW2", "test2@example.com", "testname2", UserRole.ADMIN);
+		ReflectionTestUtils.setField(member2, "id", 2L);
+
+		given(memberRepository.findAll()).willReturn(List.of(member1, member2));
+
+		//when
+		List<MembersInfoResponse> result = viewMembersInfoUseCase.execute();
+
+		//then
+		assertAll(() -> assertNotNull(result), () -> assertEquals(2, result.size()),
+			() -> assertEquals(member1.getId(), result.get(0).id()),
+			() -> assertEquals(member1.getEmail(), result.get(0).email()),
+			() -> assertEquals(member1.getName(), result.get(0).name()),
+			() -> assertEquals(member1.getUserRole().name(), result.get(0).role()),
+
+			() -> assertEquals(member2.getId(), result.get(1).id()),
+			() -> assertEquals(member2.getEmail(), result.get(1).email()),
+			() -> assertEquals(member2.getName(), result.get(1).name()),
+			() -> assertEquals(member2.getUserRole().name(), result.get(1).role()));
+		verify(memberRepository).findAll();
+	}
+
+	@Test
+	@DisplayName("멤버 목록을 조회할 때 멤버가 존재하지 않을 시 빈 목록을 반환한다.")
+	public void viewMembersInfoUseCase_멤버가_존재하지_않으면_빈_목록을_반환한다() {
+		//given
+		given(memberRepository.findAll()).willReturn(List.of());
+
+		//when
+		List<MembersInfoResponse> result = viewMembersInfoUseCase.execute();
+
+		//then
+		assertAll(() -> assertNotNull(result), () -> assertTrue(result.isEmpty()));
+		verify(memberRepository).findAll();
+	}
+}


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- 개요
- 삭제되지 않은 모든 사용자의 정보를 조회하는 기능을 구현했습니다.
closes #26 

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- 작업 내용
- Dto (MembersInfoResponse) 생성
- Service (ViewMembersInfoUseCase) 생성
- Controller (MemberController) getMembers 생성
- Member Entity에 @SQLRestriction("deleted_at IS NULL") 추가 (Soft Delete)
- Controller, Service, Repository 테스트 작성

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->