### PR TITLE
feat: 나의 댓글을 삭제하는 기능 구현

### DIFF
--- a/src/main/java/indiv/abko/taskflow/domain/comment/controller/CommentController.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/controller/CommentController.java
@@ -2,6 +2,7 @@ package indiv.abko.taskflow.domain.comment.controller;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -9,10 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToTaskCommand;
 import indiv.abko.taskflow.domain.comment.dto.request.WriteCommentRequest;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToTaskResponse;
 import indiv.abko.taskflow.domain.comment.mapper.CommentMapper;
+import indiv.abko.taskflow.domain.comment.service.DeleteMyCommentUseCase;
 import indiv.abko.taskflow.domain.comment.service.WriteCommentToTaskUseCase;
 import indiv.abko.taskflow.global.auth.AuthMember;
 import indiv.abko.taskflow.global.dto.CommonResponse;
@@ -24,13 +27,17 @@ import lombok.RequiredArgsConstructor;
 @RequestMapping("/api")
 public class CommentController {
 	private final WriteCommentToTaskUseCase writeCommentToTaskUseCase;
+	private final DeleteMyCommentUseCase deleteMyCommentUseCase;
 	private final CommentMapper commentMapper;
 
 	@PostMapping("/tasks/{taskId}/comments")
 	@ResponseStatus(HttpStatus.CREATED)
-	public CommonResponse<WriteCommentToTaskResponse> writeComment(@AuthenticationPrincipal AuthMember authMember,
-		@PathVariable("taskId") long taskId,
-		@Valid @RequestBody WriteCommentRequest request) {
+	public CommonResponse<WriteCommentToTaskResponse> writeComment(@AuthenticationPrincipal
+	AuthMember authMember,
+		@PathVariable("taskId")
+		long taskId,
+		@Valid @RequestBody
+		WriteCommentRequest request) {
 		if (request.parentId() == null) {
 			WriteCommentToTaskCommand command = commentMapper.toWriteCommentToTaskCommand(authMember, taskId, request);
 			WriteCommentToTaskResponse result = writeCommentToTaskUseCase.execute(command);
@@ -39,4 +46,17 @@ public class CommentController {
 			return null;
 		}
 	}
+
+	@DeleteMapping("/tasks/{taskId}/comments/{commentId}")
+	public CommonResponse<Void> deleteMyComment(@AuthenticationPrincipal
+	AuthMember member,
+		@PathVariable("taskId")
+		long taskId,
+		@PathVariable("commentId")
+		long commentId) {
+		DeleteMyCommentCommand command = commentMapper.toDeleteMyCommentCommand(member, commentId);
+		deleteMyCommentUseCase.execute(command);
+		return CommonResponse.success("댓글이 삭제되었습니다.", null);
+	}
+
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/dto/command/DeleteMyCommentCommand.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/dto/command/DeleteMyCommentCommand.java
@@ -1,0 +1,7 @@
+package indiv.abko.taskflow.domain.comment.dto.command;
+
+public record DeleteMyCommentCommand(
+	long requesterId,
+	long targetCommentId
+) {
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/exception/CommentErrorCode.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/exception/CommentErrorCode.java
@@ -1,0 +1,17 @@
+package indiv.abko.taskflow.domain.comment.exception;
+
+import org.springframework.http.HttpStatus;
+
+import indiv.abko.taskflow.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+	COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 댓글이 존재하지 않습니다"),
+	COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "댓글에 대한 권한이 없습니다");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapper.java
@@ -4,6 +4,7 @@ import java.time.ZoneOffset;
 
 import org.springframework.stereotype.Component;
 
+import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToTaskCommand;
 import indiv.abko.taskflow.domain.comment.dto.request.WriteCommentRequest;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToTaskResponse;
@@ -26,16 +27,18 @@ public class CommentMapper {
 				member.getUsername(),
 				member.getName(),
 				member.getEmail(),
-				member.getUserRole().getKey()
-			),
+				member.getUserRole().getKey()),
 			null,
 			savedComment.getCreatedAt().toInstant(ZoneOffset.UTC),
-			savedComment.getCreatedAt().toInstant(ZoneOffset.UTC)
-		);
+			savedComment.getCreatedAt().toInstant(ZoneOffset.UTC));
 	}
 
 	public WriteCommentToTaskCommand toWriteCommentToTaskCommand(AuthMember authMember, long taskId,
 		WriteCommentRequest request) {
 		return new WriteCommentToTaskCommand(authMember.memberId(), taskId, request.content());
+	}
+
+	public DeleteMyCommentCommand toDeleteMyCommentCommand(AuthMember member, long commentId) {
+		return new DeleteMyCommentCommand(member.memberId(), commentId);
 	}
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/repository/CommentRepository.java
@@ -1,8 +1,15 @@
 package indiv.abko.taskflow.domain.comment.repository;
 
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import indiv.abko.taskflow.domain.comment.entity.Comment;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
+	@EntityGraph(attributePaths = {"member"})
+	Optional<Comment> findWithAuthorById(Long id);
+
+	void deleteAllByParentComment(Comment parentComment);
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/service/DeleteMyCommentUseCase.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/service/DeleteMyCommentUseCase.java
@@ -1,0 +1,31 @@
+package indiv.abko.taskflow.domain.comment.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+import indiv.abko.taskflow.domain.comment.exception.CommentErrorCode;
+import indiv.abko.taskflow.domain.comment.repository.CommentRepository;
+import indiv.abko.taskflow.global.exception.BusinessException;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class DeleteMyCommentUseCase {
+	private final CommentRepository commentRepository;
+
+	@Transactional
+	public void execute(DeleteMyCommentCommand command) {
+		Comment comment = commentRepository.findWithAuthorById(command.targetCommentId())
+			.orElseThrow(() -> new BusinessException(CommentErrorCode.COMMENT_NOT_FOUND));
+
+		if (comment.getMember().getId() != command.requesterId()) {
+			throw new BusinessException(CommentErrorCode.COMMENT_FORBIDDEN);
+		}
+
+		// 댓글 삭제 시 대댓글 전부 삭제 필요
+		commentRepository.deleteAllByParentComment(comment);
+		commentRepository.delete(comment);
+	}
+}

--- a/src/test/java/indiv/abko/taskflow/domain/comment/controller/CommentControllerTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/controller/CommentControllerTest.java
@@ -1,5 +1,8 @@
 package indiv.abko.taskflow.domain.comment.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
@@ -15,10 +18,12 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToTaskCommand;
 import indiv.abko.taskflow.domain.comment.dto.request.WriteCommentRequest;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToTaskResponse;
 import indiv.abko.taskflow.domain.comment.mapper.CommentMapper;
+import indiv.abko.taskflow.domain.comment.service.DeleteMyCommentUseCase;
 import indiv.abko.taskflow.domain.comment.service.WriteCommentToTaskUseCase;
 import indiv.abko.taskflow.domain.user.entity.UserRole;
 import indiv.abko.taskflow.global.auth.AuthMember;
@@ -29,6 +34,9 @@ import indiv.abko.taskflow.support.ControllerTestSupport;
 public class CommentControllerTest extends ControllerTestSupport {
 	@MockitoBean
 	private WriteCommentToTaskUseCase writeCommentToTaskUseCase;
+
+	@MockitoBean
+	private DeleteMyCommentUseCase deleteMyCommentUseCase;
 
 	@MockitoBean
 	private CommentMapper commentMapper;
@@ -54,8 +62,23 @@ public class CommentControllerTest extends ControllerTestSupport {
 
 		// when & then
 		mockMvc.perform(post("/api/tasks/1/comments")
-				.contentType(MediaType.APPLICATION_JSON)
-				.content(objectMapper.writeValueAsString(request)))
+			.contentType(MediaType.APPLICATION_JSON)
+			.content(objectMapper.writeValueAsString(request)))
 			.andExpect(status().isCreated());
+	}
+
+	@Test
+	@WithMockAuthMember(memberId = 1L)
+	void 나의_댓글을_삭제한다() throws Exception {
+		// given
+		DeleteMyCommentCommand command = new DeleteMyCommentCommand(1L, 1L);
+
+		given(commentMapper.toDeleteMyCommentCommand(any(AuthMember.class), eq(1L))).willReturn(command);
+		willDoNothing().given(deleteMyCommentUseCase).execute(command);
+
+		// when & then
+		mockMvc.perform(delete("/api/tasks/1/comments/1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.message").value("댓글이 삭제되었습니다."));
 	}
 }

--- a/src/test/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapperTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapperTest.java
@@ -10,11 +10,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToTaskResponse;
 import indiv.abko.taskflow.domain.comment.entity.Comment;
 import indiv.abko.taskflow.domain.task.entity.Task;
 import indiv.abko.taskflow.domain.user.entity.Member;
 import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.global.auth.AuthMember;
 
 @ExtendWith(MockitoExtension.class)
 public class CommentMapperTest {
@@ -62,5 +64,20 @@ public class CommentMapperTest {
 		assertEquals(commentId, resp.id());
 		assertEquals(commentContent, resp.content());
 		assertEquals(taskId, resp.taskId());
+	}
+
+	@Test
+	void DeleteMyCommentCommand를_정확하게_매핑한다() {
+		// given
+		AuthMember member = new AuthMember(1L, UserRole.USER);
+		long commentId = 1L;
+
+		// when
+		DeleteMyCommentCommand command = commentMapper.toDeleteMyCommentCommand(member, commentId);
+
+		// then
+		assertNotNull(command);
+		assertEquals(member.memberId(), command.requesterId());
+		assertEquals(commentId, command.targetCommentId());
 	}
 }

--- a/src/test/java/indiv/abko/taskflow/domain/comment/service/DeleteMyCommentUseCaseTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/service/DeleteMyCommentUseCaseTest.java
@@ -1,0 +1,84 @@
+package indiv.abko.taskflow.domain.comment.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+import indiv.abko.taskflow.domain.comment.exception.CommentErrorCode;
+import indiv.abko.taskflow.domain.comment.repository.CommentRepository;
+import indiv.abko.taskflow.domain.user.entity.Member;
+import indiv.abko.taskflow.global.exception.BusinessException;
+
+@ExtendWith(MockitoExtension.class)
+public class DeleteMyCommentUseCaseTest {
+	@Mock
+	private CommentRepository commentRepository;
+
+	@InjectMocks
+	private DeleteMyCommentUseCase deleteMyCommentUseCase;
+
+	@Test
+	void 나의_댓글을_삭제한다() {
+		// given
+		Member member = Mockito.mock(Member.class);
+		given(member.getId()).willReturn(1L);
+		Comment comment = Mockito.mock(Comment.class);
+		given(comment.getMember()).willReturn(member);
+
+		DeleteMyCommentCommand command = new DeleteMyCommentCommand(1L, 1L);
+
+		given(commentRepository.findWithAuthorById(1L)).willReturn(Optional.of(comment));
+		willDoNothing().given(commentRepository).deleteAllByParentComment(comment);
+		willDoNothing().given(commentRepository).delete(comment);
+
+		// when & then
+		assertDoesNotThrow(() -> deleteMyCommentUseCase.execute(command));
+		then(commentRepository).should(times(1)).deleteAllByParentComment(comment);
+		then(commentRepository).should(times(1)).delete(comment);
+	}
+
+	@Test
+	void 댓글이_존재하지_않으면_실패한다() {
+		// given
+		DeleteMyCommentCommand command = new DeleteMyCommentCommand(1L, 1L);
+
+		Member member = Mockito.mock(Member.class);
+		given(member.getId()).willReturn(1L);
+		Comment comment = Mockito.mock(Comment.class);
+		given(comment.getMember()).willReturn(member);
+
+		given(commentRepository.findWithAuthorById(1L)).willReturn(Optional.empty());
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () -> deleteMyCommentUseCase.execute(command));
+		assertEquals(CommentErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+	}
+
+	@Test
+	void 나의_댓글이_아니면_실패한다() {
+		// given
+		DeleteMyCommentCommand command = new DeleteMyCommentCommand(2L, 1L);
+
+		Member member = Mockito.mock(Member.class);
+		given(member.getId()).willReturn(1L);
+
+		Comment comment = Mockito.mock(Comment.class);
+		given(comment.getMember()).willReturn(member);
+
+		given(commentRepository.findWithAuthorById(1L)).willReturn(Optional.of(comment));
+
+		// when & then
+		BusinessException ex = assertThrows(BusinessException.class, () -> deleteMyCommentUseCase.execute(command));
+		assertEquals(CommentErrorCode.COMMENT_FORBIDDEN, ex.getErrorCode());
+	}
+}


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- #45 
- 사용자가 자신의 댓글을 삭제하고 싶어합니다.
- 또한, 댓글 삭제 시 대댓글이 함께 삭제되어야 합니다.

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- 댓글 삭제 엔드포인트 구현
- 댓글 삭제 서비스 구현
- 댓글 삭제 테스트 완료

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->