### PR TITLE
fix: `댓글이_존재하지_않으면_실패한다` 메서드의 버그 수정

### DIFF
--- a/src/test/java/indiv/abko/taskflow/domain/comment/service/DeleteMyCommentUseCaseTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/service/DeleteMyCommentUseCaseTest.java
@@ -52,12 +52,7 @@ public class DeleteMyCommentUseCaseTest {
 		// given
 		DeleteMyCommentCommand command = new DeleteMyCommentCommand(1L, 1L);
 
-		Member member = Mockito.mock(Member.class);
-		given(member.getId()).willReturn(1L);
-		Comment comment = Mockito.mock(Comment.class);
-		given(comment.getMember()).willReturn(member);
-
-		given(commentRepository.findWithAuthorById(1L)).willReturn(Optional.empty());
+		given(commentRepository.findWithAuthorById(anyLong())).willReturn(Optional.empty());
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () -> deleteMyCommentUseCase.execute(command));
@@ -75,7 +70,7 @@ public class DeleteMyCommentUseCaseTest {
 		Comment comment = Mockito.mock(Comment.class);
 		given(comment.getMember()).willReturn(member);
 
-		given(commentRepository.findWithAuthorById(1L)).willReturn(Optional.of(comment));
+		given(commentRepository.findWithAuthorById(anyLong())).willReturn(Optional.of(comment));
 
 		// when & then
 		BusinessException ex = assertThrows(BusinessException.class, () -> deleteMyCommentUseCase.execute(command));


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- #56 
- 테스트가 실패하던 버그를 수정하였기 때문입니다.

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- `댓글이_존재하지_않으면_실패한다` 메서드의 불필요한 Stubbing 제거

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->