### PR TITLE
fix: DtoConstants를 사용하여 날짜 형식 및 시간대 일관성 유지

### DIFF
--- a/src/main/java/indiv/abko/taskflow/domain/comment/dto/response/WriteCommentToTaskResponse.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/dto/response/WriteCommentToTaskResponse.java
@@ -4,6 +4,8 @@ import java.time.Instant;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
+import indiv.abko.taskflow.global.dto.DtoConstants;
+
 public record WriteCommentToTaskResponse(
 	long id,
 	String content,
@@ -11,17 +13,15 @@ public record WriteCommentToTaskResponse(
 	long userId,
 	UserResp user,
 	Long parentId,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DtoConstants.TIME_FORMAT, timezone = DtoConstants.DISPLAY_TIME_ZONE_STRING)
 	Instant createdAt,
-	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss'Z'", timezone = "UTC")
-	Instant updatedAt
-) {
+	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = DtoConstants.TIME_FORMAT, timezone = DtoConstants.DISPLAY_TIME_ZONE_STRING)
+	Instant updatedAt) {
 	public record UserResp(
 		long id,
 		String username,
 		String name,
 		String email,
-		String role
-	) {
+		String role) {
 	}
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapper.java
@@ -12,6 +12,7 @@ import indiv.abko.taskflow.domain.comment.entity.Comment;
 import indiv.abko.taskflow.domain.task.entity.Task;
 import indiv.abko.taskflow.domain.user.entity.Member;
 import indiv.abko.taskflow.global.auth.AuthMember;
+import indiv.abko.taskflow.global.dto.DtoConstants;
 
 @Component
 public class CommentMapper {
@@ -29,8 +30,8 @@ public class CommentMapper {
 				member.getEmail(),
 				member.getUserRole().getKey()),
 			null,
-			savedComment.getCreatedAt().toInstant(ZoneOffset.UTC),
-			savedComment.getCreatedAt().toInstant(ZoneOffset.UTC));
+			savedComment.getCreatedAt().toInstant(DtoConstants.REAL_TIME_ZONE_OFFSET),
+			savedComment.getCreatedAt().toInstant(DtoConstants.REAL_TIME_ZONE_OFFSET));
 	}
 
 	public WriteCommentToTaskCommand toWriteCommentToTaskCommand(AuthMember authMember, long taskId,


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- #58 
- `DtoConstants` 를 사용하여 일관성을 유지하도록 수정하였습니다.

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- `CommentMapper` 에서 `DtoConstants` 사용하도록 수정.
- `WriteCommentToTaskResponse` 에서 `DtoConstants` 를 사용하도록 수정.

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->