### PR TITLE
fix: DtoConstants를 인터페이스에서 클래스으로 변경하여 상수 정의 방식 개선

### DIFF
--- a/src/main/java/indiv/abko/taskflow/global/dto/DtoConstants.java
+++ b/src/main/java/indiv/abko/taskflow/global/dto/DtoConstants.java
@@ -2,7 +2,11 @@ package indiv.abko.taskflow.global.dto;
 
 import java.time.ZoneOffset;
 
-public interface DtoConstants {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class DtoConstants {
     public static final String TIME_FORMAT = "yyyy-MM-dd'T'HH:mm:ss'Z'";
     public static final String DISPLAY_TIME_ZONE_STRING = "UTC";
     // 한국시간입니다


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- 상수 모음을 위하여 `interface` 를 사용하는 것이 안티패턴으로 간주되어 `final class` 를 사용하도록 변경하였습니다.

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- `DtoConstants` 를 `interface` 에서 `final class` 로 변경.

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->