### PR TITLE
feat: TeamService Api 작성 및 팀 추가 가능 멤버 조회 메서드 멤버 도메인으로 이동

### DIFF
--- a/src/main/java/indiv/abko/taskflow/domain/team/exception/TeamErrorCode.java
+++ b/src/main/java/indiv/abko/taskflow/domain/team/exception/TeamErrorCode.java
@@ -10,7 +10,9 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum TeamErrorCode implements ErrorCode {
 	DUPLICATE_TEAM_NAME(HttpStatus.BAD_REQUEST, "팀 이름이 이미 존재합니다."),
-	NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀이 존재하지 않습니다.");
+	NOT_FOUND_TEAM(HttpStatus.NOT_FOUND, "팀이 존재하지 않습니다."),
+	NOT_TEAM_MEMBER(HttpStatus.BAD_REQUEST, "사용자가 팀 멤버가 아닙니다"),
+	;
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/indiv/abko/taskflow/domain/team/repository/TeamMemberRepository.java
+++ b/src/main/java/indiv/abko/taskflow/domain/team/repository/TeamMemberRepository.java
@@ -11,4 +11,6 @@ import indiv.abko.taskflow.domain.team.entity.TeamMemberId;
 public interface TeamMemberRepository extends JpaRepository<TeamMember, TeamMemberId> {
 	@EntityGraph(attributePaths = {"id.team", "id.member"})
 	List<TeamMember> findAllWithFetchBy();
+
+	boolean existsById(TeamMemberId teamMemberId);
 }

--- a/src/main/java/indiv/abko/taskflow/domain/team/service/TeamService.java
+++ b/src/main/java/indiv/abko/taskflow/domain/team/service/TeamService.java
@@ -2,9 +2,31 @@ package indiv.abko.taskflow.domain.team.service;
 
 import org.springframework.stereotype.Service;
 
+import indiv.abko.taskflow.domain.team.entity.Team;
+import indiv.abko.taskflow.domain.team.entity.TeamMemberId;
+import indiv.abko.taskflow.domain.team.exception.TeamErrorCode;
+import indiv.abko.taskflow.domain.team.repository.TeamMemberRepository;
+import indiv.abko.taskflow.domain.team.repository.TeamRepository;
+import indiv.abko.taskflow.domain.user.entity.Member;
+import indiv.abko.taskflow.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class TeamService implements TeamServiceApi {
+	private final TeamRepository teamRepository;
+	private final TeamMemberRepository teamMemberRepository;
+
+	@Override
+	public Team getByIdOrThrow(Long teamId) {
+		return teamRepository.findById(teamId).
+			orElseThrow(() -> new BusinessException(TeamErrorCode.NOT_FOUND_TEAM));
+	}
+
+	@Override
+	public void assertMemberInTeamOrThrow(Team team, Member member) {
+		if (!teamMemberRepository.existsById(new TeamMemberId(team, member))) {
+			throw new BusinessException(TeamErrorCode.NOT_TEAM_MEMBER);
+		}
+	}
 }

--- a/src/main/java/indiv/abko/taskflow/domain/team/service/TeamService.java
+++ b/src/main/java/indiv/abko/taskflow/domain/team/service/TeamService.java
@@ -1,6 +1,7 @@
 package indiv.abko.taskflow.domain.team.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import indiv.abko.taskflow.domain.team.entity.Team;
 import indiv.abko.taskflow.domain.team.entity.TeamMemberId;
@@ -18,12 +19,14 @@ public class TeamService implements TeamServiceApi {
 	private final TeamMemberRepository teamMemberRepository;
 
 	@Override
+	@Transactional(readOnly = true)
 	public Team getByIdOrThrow(Long teamId) {
 		return teamRepository.findById(teamId).
 			orElseThrow(() -> new BusinessException(TeamErrorCode.NOT_FOUND_TEAM));
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public void assertMemberInTeamOrThrow(Team team, Member member) {
 		if (!teamMemberRepository.existsById(new TeamMemberId(team, member))) {
 			throw new BusinessException(TeamErrorCode.NOT_TEAM_MEMBER);

--- a/src/main/java/indiv/abko/taskflow/domain/team/service/TeamServiceApi.java
+++ b/src/main/java/indiv/abko/taskflow/domain/team/service/TeamServiceApi.java
@@ -1,24 +1,10 @@
 package indiv.abko.taskflow.domain.team.service;
 
-import java.util.List;
-
-import indiv.abko.taskflow.domain.user.dto.MemberInfoResponse;
+import indiv.abko.taskflow.domain.team.entity.Team;
+import indiv.abko.taskflow.domain.user.entity.Member;
 
 public interface TeamServiceApi {
-	// TODO: 팀이 존재하지 않으면 "팀을 찾을 수 없습니다"라는 메시지로 404 오류 반환
-	default void existsById(Long teamId) {
+	Team getByIdOrThrow(Long teamId);
 
-	}
-
-	// TODO: 멤버가 팀에 속하지 않으면 "사용자가 팀 멤버가 아닙니다"라는 메시지로 400 오류 반환
-	default void existsMemberInTeam(Long teamId, Long memberId) {
-
-	}
-
-	// TODO: 해당 팀에 속하지 않고, 삭제되지 않은 모든 사용자 목록 반환
-	default List<MemberInfoResponse> getAvailableMembersForTeam(Long teamId) {
-		// MemberInfoResponse 사용 예시
-		// new MemberInfoResponse(member.getId(), member.getUsername(), member.getEmail(), member.getName(), member.getUserRole().name(), member.getCreatedAt())
-		return null;
-	}
+	void assertMemberInTeamOrThrow(Team team, Member member);
 }

--- a/src/main/java/indiv/abko/taskflow/domain/user/repository/MemberRepository.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/repository/MemberRepository.java
@@ -1,11 +1,30 @@
 package indiv.abko.taskflow.domain.user.repository;
 
-import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
 
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import indiv.abko.taskflow.domain.team.entity.Team;
 import indiv.abko.taskflow.domain.user.entity.Member;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsByUsername(String username);
 
 	boolean existsByEmail(String email);
+
+	@Query("""
+		select m
+		from Member m
+		where not exists (
+		    select 1
+		    from TeamMember tm
+		    where tm.id.member = m
+		      and tm.id.team   = :team
+		)
+		order by m.createdAt desc
+		""")
+	List<Member> findAvailableMembersForTeam(@Param("team") Team team);
+
 }

--- a/src/main/java/indiv/abko/taskflow/domain/user/service/MemberService.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/service/MemberService.java
@@ -15,23 +15,27 @@ import lombok.RequiredArgsConstructor;
 public class MemberService implements MemberServiceApi {
 	private final MemberRepository memberRepository;
 
+	@Override
 	@Transactional(readOnly = true)
 	public Member getByIdOrThrow(long memberId) {
 		return memberRepository.findById(memberId)
 			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
 	}
 
+	@Override
 	@Transactional
 	public Member createMember(String username, String password, String email, String name) {
 		Member member = Member.of(username, password, email, name, UserRole.USER);
 		return memberRepository.save(member);
 	}
 
+	@Override
 	@Transactional(readOnly = true)
 	public boolean existsByUsername(String username) {
 		return memberRepository.existsByUsername(username);
 	}
 
+	@Override
 	@Transactional(readOnly = true)
 	public boolean existsByEmail(String email) {
 		return memberRepository.existsByEmail(email);


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- 개요
- Member 작업에 필요한 Team Service Api를 작성하였습니다.
- closes #68 

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- 작업 내용
- Team ErrorCode (NOT_TEAM_MEMBER)
- Team Service Api (getByIdOrThrow, assertMemberInTeamOrThrow)
- Team Repository (existsById)
- Member Repository (findVailableMembersForTeam) (기존 도메인 Team -> Member 이동)
- 단위 테스트 작성

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->