### PR TITLE
fix: AuthMember 객체 생성 시 `userRole` 데이터 제거

### DIFF
--- a/src/main/java/indiv/abko/taskflow/global/auth/AuthMember.java
+++ b/src/main/java/indiv/abko/taskflow/global/auth/AuthMember.java
@@ -1,9 +1,6 @@
 package indiv.abko.taskflow.global.auth;
 
-import indiv.abko.taskflow.domain.user.entity.UserRole;
-
 public record AuthMember(
-	long memberId,
-	UserRole userRole
+	long memberId
 ) {
 }

--- a/src/main/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverter.java
+++ b/src/main/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverter.java
@@ -1,30 +1,31 @@
 package indiv.abko.taskflow.global.jwt;
 
-import indiv.abko.taskflow.domain.user.entity.UserRole;
-import indiv.abko.taskflow.global.auth.AuthMember;
 import java.util.Collection;
 import java.util.Collections;
+
 import org.springframework.core.convert.converter.Converter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
+import indiv.abko.taskflow.global.auth.AuthMember;
+
 @Component
 public class JwtAuthenticationConverter implements Converter<Jwt, JwtAuthenticationToken> {
 
-    private static final String AUTHORITIES_KEY = "auth";
+	private static final String AUTHORITIES_KEY = "auth";
 
-    @Override
-    public JwtAuthenticationToken convert(Jwt jwt) {
-        long memberId = Long.parseLong(jwt.getSubject());
-        UserRole userRole = UserRole.valueOf(jwt.getClaimAsString(AUTHORITIES_KEY));
+	@Override
+	public JwtAuthenticationToken convert(Jwt jwt) {
+		long memberId = Long.parseLong(jwt.getSubject());
+		String userRole = jwt.getClaimAsString(AUTHORITIES_KEY);
 
-        AuthMember authMember = new AuthMember(memberId, userRole);
+		AuthMember authMember = new AuthMember(memberId);
 
-        Collection<? extends GrantedAuthority> authorities =
-                Collections.singletonList(new SimpleGrantedAuthority(userRole.getKey()));
+		Collection<? extends GrantedAuthority> authorities =
+			Collections.singletonList(new SimpleGrantedAuthority(userRole));
 
-        return new JwtAuthenticationToken(authMember, jwt, authorities);
-    }
+		return new JwtAuthenticationToken(authMember, jwt, authorities);
+	}
 }

--- a/src/main/java/indiv/abko/taskflow/global/jwt/JwtUtil.java
+++ b/src/main/java/indiv/abko/taskflow/global/jwt/JwtUtil.java
@@ -8,7 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 
-import indiv.abko.taskflow.global.auth.AuthMember;
+import indiv.abko.taskflow.domain.user.entity.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
@@ -37,13 +37,13 @@ public class JwtUtil {
 		this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
 	}
 
-	public String createAccessToken(AuthMember authMember) {
+	public String createAccessToken(Long memberId, UserRole userRole) {
 		long now = (new Date()).getTime();
 		Date validity = new Date(now + this.accessTokenValiditySeconds * 1000);
 
 		return Jwts.builder()
-			.setSubject(String.valueOf(authMember.memberId()))
-			.claim(AUTHORITIES_KEY, authMember.userRole().name())
+			.setSubject(String.valueOf(memberId))
+			.claim(AUTHORITIES_KEY, userRole.getKey())
 			.setIssuedAt(new Date(now))
 			.signWith(key, signatureAlgorithm)
 			.setExpiration(validity)

--- a/src/test/java/indiv/abko/taskflow/domain/auth/controller/AuthControllerTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/auth/controller/AuthControllerTest.java
@@ -20,6 +20,7 @@ import indiv.abko.taskflow.domain.auth.dto.command.RegisterCommand;
 import indiv.abko.taskflow.domain.auth.dto.request.RegisterRequest;
 import indiv.abko.taskflow.domain.auth.dto.response.RegisterResponse;
 import indiv.abko.taskflow.domain.auth.mapper.AuthMapper;
+import indiv.abko.taskflow.domain.auth.service.LoginUseCase;
 import indiv.abko.taskflow.domain.auth.service.RegisterUseCase;
 import indiv.abko.taskflow.support.ControllerTestSupport;
 
@@ -28,6 +29,9 @@ public class AuthControllerTest extends ControllerTestSupport {
 
 	@MockitoBean
 	private RegisterUseCase registerUseCase;
+
+	@MockitoBean
+	private LoginUseCase loginUseCase;
 
 	@MockitoBean
 	private AuthMapper authMapper;
@@ -65,7 +69,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 		@Test
 		void 아이디_검증에_실패하여_회원가입에_실패한다() throws Exception {
 			// given
-			RegisterRequest request = new RegisterRequest("", "test@test.com", "password123!", "testName");
+			RegisterRequest request = new RegisterRequest("", "password123!", "test@test.com", "testName");
 
 			// when & then
 			mockMvc.perform(
@@ -79,7 +83,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 		@Test
 		void 이메일_검증에_실패하여_회원가입에_실패한다() throws Exception {
 			// given
-			RegisterRequest request = new RegisterRequest("test", "test", "password123!", "testName");
+			RegisterRequest request = new RegisterRequest("test", "password123!", "test", "testName");
 
 			// when & then
 			mockMvc.perform(
@@ -93,7 +97,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 		@Test
 		void 비밀번호_검증에_실패하여_회원가입에_실패한다() throws Exception {
 			// given
-			RegisterRequest request = new RegisterRequest("test", "test@test.com", "pass", "testName");
+			RegisterRequest request = new RegisterRequest("test", "pass", "test@test.com", "testName");
 
 			// when & then
 			mockMvc.perform(
@@ -107,7 +111,7 @@ public class AuthControllerTest extends ControllerTestSupport {
 		@Test
 		void 이름_검증에_실패하여_회원가입에_실패한다() throws Exception {
 			// given
-			RegisterRequest request = new RegisterRequest("test", "test@test.com", "password123!", "");
+			RegisterRequest request = new RegisterRequest("test", "password123!", "test@test.com", "");
 
 			// when & then
 			mockMvc.perform(

--- a/src/test/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapperTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapperTest.java
@@ -69,7 +69,7 @@ public class CommentMapperTest {
 	@Test
 	void DeleteMyCommentCommand를_정확하게_매핑한다() {
 		// given
-		AuthMember member = new AuthMember(1L, UserRole.USER);
+		AuthMember member = new AuthMember(1L);
 		long commentId = 1L;
 
 		// when

--- a/src/test/java/indiv/abko/taskflow/global/auth/WithMockAuthMemberSecurityContextFactory.java
+++ b/src/test/java/indiv/abko/taskflow/global/auth/WithMockAuthMemberSecurityContextFactory.java
@@ -10,13 +10,15 @@ import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithSecurityContextFactory;
 
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+
 public class WithMockAuthMemberSecurityContextFactory implements WithSecurityContextFactory<WithMockAuthMember> {
 	@Override
 	public SecurityContext createSecurityContext(WithMockAuthMember withMockAuthMember) {
 		SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
-		AuthMember authMember = new AuthMember(withMockAuthMember.memberId(), withMockAuthMember.userRole());
+		AuthMember authMember = new AuthMember(withMockAuthMember.memberId());
 
-		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(authMember.userRole().getKey()));
+		List<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority(UserRole.USER.getKey()));
 		Authentication authentication = new UsernamePasswordAuthenticationToken(authMember, null, authorities);
 
 		securityContext.setAuthentication(authentication);

--- a/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverterUnitTest.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationConverterUnitTest.java
@@ -21,13 +21,13 @@ class JwtAuthenticationConverterUnitTest {
 	void convert() {
 		// given
 		long memberId = 1L;
-		UserRole userRole = UserRole.USER;
+		String userRole = UserRole.USER.getKey();
 		String tokenValue = "test-token";
 
 		Jwt jwt = Jwt.withTokenValue(tokenValue)
 			.header("alg", "HS256")
 			.subject(String.valueOf(memberId))
-			.claim("auth", userRole.name())
+			.claim("auth", userRole)
 			.issuedAt(Instant.now())
 			.expiresAt(Instant.now().plusSeconds(60))
 			.build();
@@ -41,10 +41,9 @@ class JwtAuthenticationConverterUnitTest {
 
 		AuthMember authMember = (AuthMember)authentication.getPrincipal();
 		assertThat(authMember.memberId()).isEqualTo(memberId);
-		assertThat(authMember.userRole()).isEqualTo(userRole);
 
 		assertThat(authentication.getAuthorities()).hasSize(1);
 		GrantedAuthority authority = authentication.getAuthorities().iterator().next();
-		assertThat(authority.getAuthority()).isEqualTo(userRole.getKey());
+		assertThat(authority.getAuthority()).isEqualTo(userRole);
 	}
 }

--- a/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationTokenUnitTest.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/JwtAuthenticationTokenUnitTest.java
@@ -19,9 +19,10 @@ class JwtAuthenticationTokenUnitTest {
 	@DisplayName("JwtAuthenticationToken 생성 시 principal, credentials, authorities가 올바르게 설정되고 인증 상태가 true가 된다")
 	void createToken() {
 		// given
-		AuthMember principal = new AuthMember(1L, UserRole.USER);
+		AuthMember principal = new AuthMember(1L);
 		String credentials = "jwt-token-string";
-		Collection<GrantedAuthority> authorities = Collections.singletonList(new SimpleGrantedAuthority(UserRole.USER.getKey()));
+		Collection<GrantedAuthority> authorities = Collections.singletonList(
+			new SimpleGrantedAuthority(UserRole.USER.getKey()));
 
 		// when
 		JwtAuthenticationToken token = new JwtAuthenticationToken(principal, credentials, authorities);

--- a/src/test/java/indiv/abko/taskflow/global/jwt/TestJwtUtil.java
+++ b/src/test/java/indiv/abko/taskflow/global/jwt/TestJwtUtil.java
@@ -1,29 +1,30 @@
 package indiv.abko.taskflow.global.jwt;
 
+import java.security.Key;
+import java.util.Date;
+
+import indiv.abko.taskflow.domain.user.entity.UserRole;
 import indiv.abko.taskflow.global.auth.AuthMember;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 
-import java.security.Key;
-import java.util.Date;
-
 public class TestJwtUtil {
 
-    private static final String AUTHORITIES_KEY = "auth";
-    private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
+	private static final String AUTHORITIES_KEY = "auth";
+	private static final SignatureAlgorithm signatureAlgorithm = SignatureAlgorithm.HS256;
 
-    public static String createAccessToken(AuthMember authMember, long validitySeconds, String secretKey) {
-        long now = (new Date()).getTime();
-        Date validity = new Date(now + validitySeconds * 1000);
-        Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
+	public static String createAccessToken(AuthMember authMember, long validitySeconds, String secretKey) {
+		long now = (new Date()).getTime();
+		Date validity = new Date(now + validitySeconds * 1000);
+		Key key = Keys.hmacShaKeyFor(secretKey.getBytes());
 
-        return Jwts.builder()
-                .setSubject(String.valueOf(authMember.memberId()))
-                .claim(AUTHORITIES_KEY, authMember.userRole().name())
-                .setIssuedAt(new Date(now))
-                .signWith(key, signatureAlgorithm)
-                .setExpiration(validity)
-                .compact();
-    }
+		return Jwts.builder()
+			.setSubject(String.valueOf(authMember.memberId()))
+			.claim(AUTHORITIES_KEY, UserRole.USER.getKey())
+			.setIssuedAt(new Date(now))
+			.signWith(key, signatureAlgorithm)
+			.setExpiration(validity)
+			.compact();
+	}
 }


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- AuthMember 객체 생성 시 `userRole` 데이터 제거
- #32 

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- AuthMember 객체에 userRole 정보를 제거했습니다.

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->