### PR TITLE
fix: ViewAvailableMembers 불필요한 에러 처리 삭제

### DIFF
--- a/src/main/java/indiv/abko/taskflow/domain/user/controller/MemberController.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/controller/MemberController.java
@@ -37,10 +37,9 @@ public class MemberController {
 
 	@GetMapping("/available")
 	public CommonResponse<List<MemberInfoResponse>> getAvailableMembers(
-		@RequestParam(required = true, name = "teamId") Long teamId, @AuthenticationPrincipal AuthMember authMember) {
+		@RequestParam(required = true, name = "teamId") Long teamId) {
 		return CommonResponse.success("사용 가능한 사용자 목록을 조회했습니다.",
-			viewAvailableMembersInfoUseCase.execute(teamId, authMember.memberId()));
-
+			viewAvailableMembersInfoUseCase.execute(teamId));
 	}
 
 }

--- a/src/main/java/indiv/abko/taskflow/domain/user/service/ViewAvailableMembersInfoUseCase.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/service/ViewAvailableMembersInfoUseCase.java
@@ -8,10 +8,7 @@ import org.springframework.transaction.annotation.Transactional;
 import indiv.abko.taskflow.domain.team.entity.Team;
 import indiv.abko.taskflow.domain.team.service.TeamServiceApi;
 import indiv.abko.taskflow.domain.user.dto.MemberInfoResponse;
-import indiv.abko.taskflow.domain.user.entity.Member;
-import indiv.abko.taskflow.domain.user.exception.MemberErrorCode;
 import indiv.abko.taskflow.domain.user.repository.MemberRepository;
-import indiv.abko.taskflow.global.exception.BusinessException;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,13 +18,8 @@ public class ViewAvailableMembersInfoUseCase {
 	private final TeamServiceApi teamService;
 
 	@Transactional(readOnly = true)
-	public List<MemberInfoResponse> execute(Long teamId, Long memberId) {
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new BusinessException(MemberErrorCode.MEMBER_NOT_FOUND));
-
+	public List<MemberInfoResponse> execute(Long teamId) {
 		Team team = teamService.getByIdOrThrow(teamId);
-
-		teamService.assertMemberInTeamOrThrow(team, member);
 
 		return memberRepository.findAvailableMembersForTeam(team)
 			.stream()

--- a/src/test/java/indiv/abko/taskflow/domain/user/service/ViewAvailableMembersInfoUseCaseTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/user/service/ViewAvailableMembersInfoUseCaseTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,7 +20,6 @@ import indiv.abko.taskflow.domain.team.service.TeamServiceApi;
 import indiv.abko.taskflow.domain.user.dto.MemberInfoResponse;
 import indiv.abko.taskflow.domain.user.entity.Member;
 import indiv.abko.taskflow.domain.user.entity.UserRole;
-import indiv.abko.taskflow.domain.user.exception.MemberErrorCode;
 import indiv.abko.taskflow.domain.user.repository.MemberRepository;
 import indiv.abko.taskflow.global.exception.BusinessException;
 
@@ -37,15 +35,10 @@ public class ViewAvailableMembersInfoUseCaseTest {
 	private ViewAvailableMembersInfoUseCase viewAvailableMembersInfoUseCase;
 
 	@Test
-	@DisplayName("멤버가 존재하고, 팀이 존재하고, 멤버가 팀에 존재할 때, available 멤버 목록을 정상적으로 조회한다")
+	@DisplayName("팀이 존재할 때 available 멤버 목록을 정상적으로 조회한다")
 	public void viewAvailableMembersInfoUseCase_성공() {
 		//given
 		Long teamId = 1L;
-		Long memberId = 1L;
-
-		Member member1 = Member.of("testusername", "HASHED_PW", "test@example.com", "testname", UserRole.USER);
-		ReflectionTestUtils.setField(member1, "id", 1L);
-		given(memberRepository.findById(memberId)).willReturn(Optional.of(member1));
 
 		Team team = new Team("teamName", "teamDescription");
 		given(teamService.getByIdOrThrow(teamId)).willReturn(team);
@@ -60,7 +53,7 @@ public class ViewAvailableMembersInfoUseCaseTest {
 		given(memberRepository.findAvailableMembersForTeam(team)).willReturn(expected);
 
 		//when
-		List<MemberInfoResponse> result = viewAvailableMembersInfoUseCase.execute(teamId, memberId);
+		List<MemberInfoResponse> result = viewAvailableMembersInfoUseCase.execute(teamId);
 
 		//then
 		assertThat(result).hasSize(2);
@@ -76,30 +69,8 @@ public class ViewAvailableMembersInfoUseCaseTest {
 				tuple(2L, "testusername2", "test2@example.com", "testname2", "ADMIN"),
 				tuple(3L, "testusername3", "test3@example.com", "testname3", "USER")
 			);
-		verify(memberRepository, times(1)).findById(memberId);
 		verify(teamService, times(1)).getByIdOrThrow(teamId);
-		verify(teamService, times(1)).assertMemberInTeamOrThrow(team, member1);
 		verify(memberRepository, times(1)).findAvailableMembersForTeam(team);
-	}
-
-	@Test
-	@DisplayName("멤버가 존재하지 않을 시 MEMBER_NOT_FOUND 오류를 반환한다.")
-	public void viewAvailableMembersInfoUseCase_멤버가_존재하지_않으면_MEMBER_NOT_FOUND() {
-		//given
-		Long teamId = 1L;
-		Long memberId = 1L;
-		given(memberRepository.findById(memberId)).willReturn(Optional.empty());
-
-		//when
-		BusinessException exception = assertThrows(BusinessException.class,
-			() -> viewAvailableMembersInfoUseCase.execute(teamId, memberId));
-
-		//then
-		assertAll(() -> assertEquals(MemberErrorCode.MEMBER_NOT_FOUND.getMessage(), exception.getMessage()),
-			() -> assertEquals(MemberErrorCode.MEMBER_NOT_FOUND, exception.getErrorCode()));
-
-		verify(memberRepository, times(1)).findById(memberId);
-		verifyNoInteractions(teamService);
 	}
 
 	@Test
@@ -107,52 +78,18 @@ public class ViewAvailableMembersInfoUseCaseTest {
 	public void viewAvailableMembersInfoUseCase_팀이_존재하지_않으면_NOT_FOUND_TEAM() {
 		//given
 		Long teamId = 1L;
-		Long memberId = 1L;
-		Member member1 = Member.of("testusername", "HASHED_PW", "test@example.com", "testname", UserRole.USER);
-		ReflectionTestUtils.setField(member1, "id", 1L);
-		given(memberRepository.findById(memberId)).willReturn(Optional.of(member1));
 		doThrow(new BusinessException(TeamErrorCode.NOT_FOUND_TEAM))
 			.when(teamService).getByIdOrThrow(teamId);
 
 		//when
 		BusinessException exception = assertThrows(BusinessException.class,
-			() -> viewAvailableMembersInfoUseCase.execute(teamId, memberId));
+			() -> viewAvailableMembersInfoUseCase.execute(teamId));
 
 		//then
 		assertAll(() -> assertEquals(TeamErrorCode.NOT_FOUND_TEAM.getMessage(), exception.getMessage()),
 			() -> assertEquals(TeamErrorCode.NOT_FOUND_TEAM, exception.getErrorCode()));
 
-		verify(memberRepository, times(1)).findById(memberId);
 		verify(teamService, times(1)).getByIdOrThrow(teamId);
 		verifyNoMoreInteractions(teamService);
 	}
-
-	@Test
-	@DisplayName("사용자가 팀에 속하지 않을 시 NOT_TEAM_MEMBER 오류를 반환한다.")
-	public void viewAvailableMembersInfoUseCase_사용자가_팀에_속하지_않으면_NOT_TEAM_MEMBER() {
-		//given
-		Long teamId = 1L;
-		Long memberId = 1L;
-		Member member1 = Member.of("testusername", "HASHED_PW", "test@example.com", "testname", UserRole.USER);
-		ReflectionTestUtils.setField(member1, "id", 1L);
-		given(memberRepository.findById(memberId)).willReturn(Optional.of(member1));
-		Team team = new Team("teamName", "teamDescription");
-		given(teamService.getByIdOrThrow(teamId)).willReturn(team);
-		doThrow(new BusinessException(TeamErrorCode.NOT_TEAM_MEMBER))
-			.when(teamService).assertMemberInTeamOrThrow(team, member1);
-
-		//when
-		BusinessException exception = assertThrows(BusinessException.class,
-			() -> viewAvailableMembersInfoUseCase.execute(teamId, memberId));
-
-		//then
-		assertAll(() -> assertEquals(TeamErrorCode.NOT_TEAM_MEMBER.getMessage(), exception.getMessage()),
-			() -> assertEquals(TeamErrorCode.NOT_TEAM_MEMBER, exception.getErrorCode()));
-
-		verify(memberRepository, times(1)).findById(memberId);
-		verify(teamService, times(1)).getByIdOrThrow(teamId);
-		verify(teamService, times(1)).assertMemberInTeamOrThrow(team, member1);
-		verifyNoMoreInteractions(teamService);
-	}
-
 }


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- 개요
- ViewAvailableMembersUseCase의 불필요한 에러 처리 (멤버 조회 확인, 멤버가 팀 소속인지 확인) 삭제

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- 작업 내용
- 멤버 조회 확인, 멤버 팀 소속 확인 에러 처리 삭제
- 테스트 코드 반영

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->