### PR TITLE
feat: 댓글 조회 기능 및 페이지네이션 구현

### DIFF
--- a/src/main/java/indiv/abko/taskflow/domain/comment/controller/CommentController.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/controller/CommentController.java
@@ -1,12 +1,15 @@
 package indiv.abko.taskflow.domain.comment.controller;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,10 +17,13 @@ import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToTaskCommand;
 import indiv.abko.taskflow.domain.comment.dto.request.WriteCommentRequest;
+import indiv.abko.taskflow.domain.comment.dto.response.ViewCommentsFromTaskResponse;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToCommentResponse;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToTaskResponse;
 import indiv.abko.taskflow.domain.comment.mapper.CommentMapper;
+import indiv.abko.taskflow.domain.comment.dto.command.ViewCommentsFromTaskCommand;
 import indiv.abko.taskflow.domain.comment.service.DeleteMyCommentUseCase;
+import indiv.abko.taskflow.domain.comment.service.ViewCommentsFromTaskUseCase;
 import indiv.abko.taskflow.domain.comment.service.WriteCommentToCommentUseCase;
 import indiv.abko.taskflow.domain.comment.service.WriteCommentToTaskUseCase;
 import indiv.abko.taskflow.global.auth.AuthMember;
@@ -32,6 +38,7 @@ public class CommentController {
 	private final WriteCommentToTaskUseCase writeCommentToTaskUseCase;
 	private final WriteCommentToCommentUseCase writeCommentToCommentUseCase;
 	private final DeleteMyCommentUseCase deleteMyCommentUseCase;
+	private final ViewCommentsFromTaskUseCase viewCommentsFromTaskUseCase;
 	private final CommentMapper commentMapper;
 
 	@PostMapping("/tasks/{taskId}/comments")
@@ -66,4 +73,18 @@ public class CommentController {
 		return CommonResponse.success("댓글이 삭제되었습니다.", null);
 	}
 
+	@GetMapping("/tasks/{taskId}/comments")
+	public CommonResponse<?> viewCommentsFromTask(@PathVariable("taskId")
+	long taskId,
+		@RequestParam(value = "page", defaultValue = "0")
+		int page,
+		@RequestParam(value = "size", defaultValue = "10")
+		int size,
+		@RequestParam(value = "sort", defaultValue = "newest")
+		String sort) {
+		Pageable pageable = Pageable.ofSize(size).withPage(page);
+		ViewCommentsFromTaskCommand command = commentMapper.toViewCommentsFromTaskCommand(pageable, taskId, sort);
+		ViewCommentsFromTaskResponse result = viewCommentsFromTaskUseCase.execute(command);
+		return CommonResponse.success("댓글 목록을 조회했습니다.", result);
+	}
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/dto/CommentPaginationData.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/dto/CommentPaginationData.java
@@ -1,0 +1,8 @@
+package indiv.abko.taskflow.domain.comment.dto;
+
+import java.util.List;
+
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+
+public record CommentPaginationData(List<Comment> parentComments, List<Comment> childComments) {
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/dto/command/ViewCommentsFromTaskCommand.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/dto/command/ViewCommentsFromTaskCommand.java
@@ -1,0 +1,9 @@
+package indiv.abko.taskflow.domain.comment.dto.command;
+
+import org.springframework.data.domain.Pageable;
+
+import indiv.abko.taskflow.domain.comment.enums.CommentSortOption;
+
+public record ViewCommentsFromTaskCommand(Pageable pageable, long taskid, CommentSortOption sortOption) {
+
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/dto/response/ViewCommentsFromTaskResponse.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/dto/response/ViewCommentsFromTaskResponse.java
@@ -1,0 +1,36 @@
+package indiv.abko.taskflow.domain.comment.dto.response;
+
+import java.time.Instant;
+import java.util.List;
+
+import lombok.Builder;
+
+@Builder
+public record ViewCommentsFromTaskResponse(
+    List<CommentResp> content,
+    long totalElements,
+    int totalPages,
+    int size,
+    int number) {
+
+    @Builder
+    public record CommentResp(
+        Long id,
+        String content,
+        Long taskId,
+        Long userId,
+        UserResp user,
+        Long parentId,
+        Instant createdAt,
+        Instant updatedAt) {
+    }
+
+    @Builder
+    public record UserResp(
+        Long id,
+        String username,
+        String name,
+        String email,
+        String role) {
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/entity/Comment.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/entity/Comment.java
@@ -10,6 +10,7 @@ import indiv.abko.taskflow.domain.user.entity.Member;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -39,14 +40,14 @@ public class Comment {
 	@Column(updatable = false)
 	private LocalDateTime createdAt;
 
-	@ManyToOne(optional = false)
+	@ManyToOne(optional = false, fetch = FetchType.LAZY)
 	@JoinColumn(nullable = false)
 	private Member member;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Task task;
 
-	@ManyToOne
+	@ManyToOne(fetch = FetchType.LAZY)
 	private Comment parentComment;
 
 	public static Comment of(Member member, Task task, String content) {

--- a/src/main/java/indiv/abko/taskflow/domain/comment/enums/CommentSortOption.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/enums/CommentSortOption.java
@@ -1,0 +1,6 @@
+package indiv.abko.taskflow.domain.comment.enums;
+
+public enum CommentSortOption {
+    NEWEST,
+    OLDEST
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapper.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/mapper/CommentMapper.java
@@ -1,14 +1,23 @@
 package indiv.abko.taskflow.domain.comment.mapper;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
 import indiv.abko.taskflow.domain.comment.dto.command.DeleteMyCommentCommand;
+import indiv.abko.taskflow.domain.comment.dto.command.ViewCommentsFromTaskCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToCommentCommand;
 import indiv.abko.taskflow.domain.comment.dto.command.WriteCommentToTaskCommand;
 import indiv.abko.taskflow.domain.comment.dto.request.WriteCommentRequest;
+import indiv.abko.taskflow.domain.comment.dto.response.ViewCommentsFromTaskResponse;
+import indiv.abko.taskflow.domain.comment.dto.response.ViewCommentsFromTaskResponse.CommentResp;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToCommentResponse;
 import indiv.abko.taskflow.domain.comment.dto.response.WriteCommentToTaskResponse;
 import indiv.abko.taskflow.domain.comment.entity.Comment;
+import indiv.abko.taskflow.domain.comment.enums.CommentSortOption;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginator.PagedComments;
 import indiv.abko.taskflow.domain.task.entity.Task;
 import indiv.abko.taskflow.domain.user.entity.Member;
 import indiv.abko.taskflow.global.auth.AuthMember;
@@ -65,5 +74,50 @@ public class CommentMapper {
 	public WriteCommentToCommentCommand toWriteCommentToCommentCommand(AuthMember authMember, long taskId,
 		WriteCommentRequest request) {
 		return new WriteCommentToCommentCommand(authMember.memberId(), taskId, request.parentId(), request.content());
+	}
+
+	public ViewCommentsFromTaskCommand toViewCommentsFromTaskCommand(Pageable pageable, long taskId, String sort) {
+		CommentSortOption sortOption = "newest".equalsIgnoreCase(sort)
+			? CommentSortOption.NEWEST
+			: CommentSortOption.OLDEST;
+		return new ViewCommentsFromTaskCommand(pageable, taskId, sortOption);
+	}
+
+	public ViewCommentsFromTaskResponse toViewCommentsFromTaskResponse(PagedComments results) {
+		List<ViewCommentsFromTaskResponse.CommentResp> commentResps = new ArrayList<>();
+
+		for (Comment comment : results.comments()) {
+			Member author = comment.getMember();
+			Long parentCommentId = comment.getParentComment() != null
+				? comment.getParentComment().getId() : null;
+
+			ViewCommentsFromTaskResponse.UserResp userResp = ViewCommentsFromTaskResponse.UserResp.builder()
+				.id(author.getId())
+				.username(author.getUsername())
+				.name(author.getName())
+				.email(author.getEmail())
+				.role(author.getUserRole().name())
+				.build();
+
+			CommentResp commentResp = ViewCommentsFromTaskResponse.CommentResp.builder()
+				.id(comment.getId())
+				.content(comment.getContent())
+				.taskId(comment.getTask().getId())
+				.userId(author.getId())
+				.user(userResp)
+				.createdAt(comment.getCreatedAt().toInstant(DtoConstants.REAL_TIME_ZONE_OFFSET))
+				.updatedAt(comment.getCreatedAt().toInstant(DtoConstants.REAL_TIME_ZONE_OFFSET))
+				.parentId(parentCommentId)
+				.build();
+			commentResps.add(commentResp);
+		}
+
+		return ViewCommentsFromTaskResponse.builder()
+			.content(commentResps)
+			.totalElements(results.totalElements())
+			.totalPages(results.totalPages())
+			.size(results.size())
+			.number(results.number())
+			.build();
 	}
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/repository/CommentRepository.java
@@ -1,5 +1,6 @@
 package indiv.abko.taskflow.domain.comment.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.EntityGraph;
@@ -12,4 +13,13 @@ public interface CommentRepository extends JpaRepository<Comment, Long> {
 	Optional<Comment> findWithAuthorById(Long id);
 
 	void deleteAllByParentComment(Comment parentComment);
+
+	@EntityGraph(attributePaths = {"member", "task"})
+	List<Comment> findWithDetailsByTaskIdOrderByCreatedAtDesc(long taskId);
+
+	@EntityGraph(attributePaths = {"member", "task"})
+	List<Comment> findWithDetailsByTaskIdOrderByCreatedAt(long taskId);
+
+	@EntityGraph(attributePaths = {"member", "parentComment"})
+	List<Comment> findWithDetailByParentCommentIsInOrderByCreatedAt(List<Comment> parentComments);
 }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/service/ViewCommentsFromTaskUseCase.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/service/ViewCommentsFromTaskUseCase.java
@@ -1,0 +1,53 @@
+package indiv.abko.taskflow.domain.comment.service;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import indiv.abko.taskflow.domain.comment.dto.CommentPaginationData;
+import indiv.abko.taskflow.domain.comment.dto.command.ViewCommentsFromTaskCommand;
+import indiv.abko.taskflow.domain.comment.dto.response.ViewCommentsFromTaskResponse;
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+import indiv.abko.taskflow.domain.comment.enums.CommentSortOption;
+import indiv.abko.taskflow.domain.comment.mapper.CommentMapper;
+import indiv.abko.taskflow.domain.comment.repository.CommentRepository;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginator;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginatorFactory;
+import indiv.abko.taskflow.domain.comment.util.PaginationContext;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginator.PagedComments;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ViewCommentsFromTaskUseCase {
+    private final CommentRepository commentRepository;
+    private final CommentMapper commentMapper;
+    private final HierarchicalCommentsPaginatorFactory paginatorFactory;
+
+    @Transactional(readOnly = true)
+    public ViewCommentsFromTaskResponse execute(ViewCommentsFromTaskCommand command) {
+        // 중요: 댓글은 계층적으로 정렬되어 반환됩니다. 
+        // 부모 댓글들이 먼저 정렬되고, 
+        // 각 부모 댓글 바로 다음에 해당 대댓글들이 시간순으로 배치됩니다.
+
+        List<Comment> parentComments = getParentComments(command.sortOption(), command.taskid());
+        List<Comment> childComments = commentRepository
+            .findWithDetailByParentCommentIsInOrderByCreatedAt(parentComments);
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = paginatorFactory.create(commentPaginationData);
+        PaginationContext paginationContext = new PaginationContext(command.pageable());
+
+        PagedComments results = paginator.paginate(paginationContext);
+        return commentMapper.toViewCommentsFromTaskResponse(results);
+    }
+
+    private List<Comment> getParentComments(CommentSortOption sortOption, long taskId) {
+        if (sortOption == CommentSortOption.NEWEST) {
+            return commentRepository.findWithDetailsByTaskIdOrderByCreatedAtDesc(taskId);
+        } else {
+            return commentRepository.findWithDetailsByTaskIdOrderByCreatedAt(taskId);
+        }
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginator.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginator.java
@@ -1,0 +1,81 @@
+package indiv.abko.taskflow.domain.comment.util;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import indiv.abko.taskflow.domain.comment.dto.CommentPaginationData;
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+
+public class HierarchicalCommentsPaginator {
+    private final List<Comment> parentComments;
+    private final List<Comment> childComments;
+
+    private Map<Long, List<Comment>> childCommentsMappingToParent = new HashMap<>();
+
+    public HierarchicalCommentsPaginator(CommentPaginationData commentPaginationData) {
+        this.parentComments = commentPaginationData.parentComments();
+        this.childComments = commentPaginationData.childComments();
+    }
+
+    public PagedComments paginate(PaginationContext paginationContext) {
+        childCommentsMappingToParent = childComments.stream()
+            .collect(Collectors.groupingBy(comment -> comment.getParentComment().getId()));
+        List<Comment> pagedComments = paginateHierarchicalComments(paginationContext);
+        return calculatePageInfos(pagedComments, paginationContext);
+    }
+
+    private List<Comment> paginateHierarchicalComments(PaginationContext paginationContext) {
+        List<Comment> pagedComments = new ArrayList<>();
+
+        for (Comment parent : parentComments) {
+            if (paginationContext.isInRange()) {
+                pagedComments.add(parent);
+                paginationContext.next();
+
+                if (paginationContext.shouldStop()) {
+                    return pagedComments;
+                }
+
+                List<Comment> childComments = getChildComments(parent);
+                for (Comment child : childComments) {
+                    pagedComments.add(child);
+                    paginationContext.next();
+
+                    if (paginationContext.shouldStop()) {
+                        return pagedComments;
+                    }
+                }
+            } else {
+                paginationContext.next();
+                if (paginationContext.shouldStop()) {
+                    break;
+                }
+            }
+        }
+
+        return pagedComments;
+    }
+
+    private PagedComments calculatePageInfos(List<Comment> pagedComments, PaginationContext paginationContext) {
+        long totalElements = parentComments.size() + childComments.size();
+        int totalPages = (int)Math.ceil((double)totalElements / paginationContext.getSize());
+        int size = pagedComments.size();
+        int number = paginationContext.getNumber();
+        return new PagedComments(pagedComments, totalElements, totalPages, size, number);
+    }
+
+    private List<Comment> getChildComments(Comment parent) {
+        return childCommentsMappingToParent.getOrDefault(parent.getId(), List.of());
+    }
+
+    public record PagedComments(
+        List<Comment> comments,
+        long totalElements,
+        int totalPages,
+        int size,
+        int number) {
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginator.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginator.java
@@ -28,25 +28,27 @@ public class HierarchicalCommentsPaginator {
     }
 
     private List<Comment> paginateHierarchicalComments(PaginationContext paginationContext) {
-        List<Comment> pagedComments = new ArrayList<>();
+        List<Comment> pagedComments = new ArrayList<>(); // 최종 페이지네이션 된 결과물
 
         for (Comment parent : parentComments) {
+            // 상위댓글
             if (paginationContext.isInRange()) {
                 pagedComments.add(parent);
-                paginationContext.next();
-            } else {
-                paginationContext.next();
             }
+
+            paginationContext.next();
 
             if (paginationContext.shouldStop()) {
                 return pagedComments;
             }
 
+            // 대댓글
             List<Comment> childComments = getChildComments(parent);
             for (Comment child : childComments) {
                 if (paginationContext.isInRange()) {
                     pagedComments.add(child);
                 }
+
                 paginationContext.next();
 
                 if (paginationContext.shouldStop()) {

--- a/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginator.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginator.java
@@ -34,24 +34,23 @@ public class HierarchicalCommentsPaginator {
             if (paginationContext.isInRange()) {
                 pagedComments.add(parent);
                 paginationContext.next();
+            } else {
+                paginationContext.next();
+            }
+
+            if (paginationContext.shouldStop()) {
+                return pagedComments;
+            }
+
+            List<Comment> childComments = getChildComments(parent);
+            for (Comment child : childComments) {
+                if (paginationContext.isInRange()) {
+                    pagedComments.add(child);
+                }
+                paginationContext.next();
 
                 if (paginationContext.shouldStop()) {
                     return pagedComments;
-                }
-
-                List<Comment> childComments = getChildComments(parent);
-                for (Comment child : childComments) {
-                    pagedComments.add(child);
-                    paginationContext.next();
-
-                    if (paginationContext.shouldStop()) {
-                        return pagedComments;
-                    }
-                }
-            } else {
-                paginationContext.next();
-                if (paginationContext.shouldStop()) {
-                    break;
                 }
             }
         }

--- a/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginatorFactory.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginatorFactory.java
@@ -1,0 +1,11 @@
+package indiv.abko.taskflow.domain.comment.util;
+
+import org.springframework.stereotype.Component;
+import indiv.abko.taskflow.domain.comment.dto.CommentPaginationData;
+
+@Component
+public class HierarchicalCommentsPaginatorFactory {
+    public HierarchicalCommentsPaginator create(CommentPaginationData commentPaginationData) {
+        return new HierarchicalCommentsPaginator(commentPaginationData);
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/domain/comment/util/PaginationContext.java
+++ b/src/main/java/indiv/abko/taskflow/domain/comment/util/PaginationContext.java
@@ -1,0 +1,35 @@
+package indiv.abko.taskflow.domain.comment.util;
+
+import org.springframework.data.domain.Pageable;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class PaginationContext {
+    private final long startIdx;
+    private final long endIdx;
+    private final int size;
+    private final int number;
+    private long currentIdx = 0L;
+
+    public PaginationContext(Pageable pageable) {
+        startIdx = pageable.getOffset();
+        endIdx = startIdx + pageable.getPageSize();
+        size = pageable.getPageSize() == 0 ? 10 : pageable.getPageSize();
+        number = pageable.getPageNumber();
+    }
+
+    public boolean isInRange() {
+        return endIdx > currentIdx && currentIdx >= startIdx;
+    }
+
+    public boolean shouldStop() {
+        return currentIdx >= endIdx;
+    }
+
+    public void next() {
+        currentIdx++;
+    }
+}

--- a/src/main/java/indiv/abko/taskflow/domain/user/service/MemberServiceApi.java
+++ b/src/main/java/indiv/abko/taskflow/domain/user/service/MemberServiceApi.java
@@ -14,6 +14,5 @@ public interface MemberServiceApi {
 
 	boolean existsByEmail(String email);
 
-	// TODO: 혜준님을 위한 선물
 	Optional<Member> findByUsername(String username);
 }

--- a/src/test/java/indiv/abko/taskflow/domain/comment/service/ViewCommentsFromTaskUseCaseTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/service/ViewCommentsFromTaskUseCaseTest.java
@@ -1,0 +1,114 @@
+package indiv.abko.taskflow.domain.comment.service;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import indiv.abko.taskflow.domain.comment.dto.CommentPaginationData;
+import indiv.abko.taskflow.domain.comment.dto.command.ViewCommentsFromTaskCommand;
+import indiv.abko.taskflow.domain.comment.dto.response.ViewCommentsFromTaskResponse;
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+import indiv.abko.taskflow.domain.comment.enums.CommentSortOption;
+import indiv.abko.taskflow.domain.comment.mapper.CommentMapper;
+import indiv.abko.taskflow.domain.comment.repository.CommentRepository;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginator;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginatorFactory;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginator.PagedComments;
+
+@ExtendWith(MockitoExtension.class)
+public class ViewCommentsFromTaskUseCaseTest {
+    @Mock
+    private CommentRepository commentRepository;
+
+    @Mock
+    private CommentMapper commentMapper;
+
+    @Mock
+    private HierarchicalCommentsPaginatorFactory paginatorFactory;
+
+    @Mock
+    private HierarchicalCommentsPaginator mockPaginator;
+
+    @InjectMocks
+    private ViewCommentsFromTaskUseCase viewCommentsFromTaskUseCase;
+
+    @Test
+    void 성공적으로_task의_댓글을_계층적으로_조회한다() {
+        // given
+        long taskId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        ViewCommentsFromTaskCommand command = new ViewCommentsFromTaskCommand(pageable, taskId,
+            CommentSortOption.NEWEST);
+
+        List<Comment> parentComments = List.of();
+        List<Comment> childComments = List.of();
+        PagedComments pagedComments = new PagedComments(List.of(), 0L, 0, 0, 0);
+        ViewCommentsFromTaskResponse expectedResponse = ViewCommentsFromTaskResponse.builder()
+            .content(List.of())
+            .totalElements(0L)
+            .totalPages(0)
+            .size(0)
+            .number(0)
+            .build();
+
+        given(commentRepository.findWithDetailsByTaskIdOrderByCreatedAtDesc(taskId)).willReturn(parentComments);
+        given(commentRepository.findWithDetailByParentCommentIsInOrderByCreatedAt(parentComments))
+            .willReturn(childComments);
+        given(paginatorFactory.create(any(CommentPaginationData.class))).willReturn(mockPaginator);
+        given(mockPaginator.paginate(any())).willReturn(pagedComments);
+        given(commentMapper.toViewCommentsFromTaskResponse(pagedComments)).willReturn(expectedResponse);
+
+        // when
+        ViewCommentsFromTaskResponse result = viewCommentsFromTaskUseCase.execute(command);
+
+        // then
+        assertNotNull(result);
+        then(paginatorFactory).should(times(1)).create(any(CommentPaginationData.class));
+        then(mockPaginator).should(times(1)).paginate(any());
+        then(commentMapper).should(times(1)).toViewCommentsFromTaskResponse(pagedComments);
+    }
+
+    @Test
+    void OLDEST_정렬옵션으로_댓글을_조회한다() {
+        // given
+        long taskId = 1L;
+        Pageable pageable = PageRequest.of(0, 10);
+        ViewCommentsFromTaskCommand command = new ViewCommentsFromTaskCommand(pageable, taskId,
+            CommentSortOption.OLDEST);
+
+        List<Comment> parentComments = List.of();
+        List<Comment> childComments = List.of();
+        PagedComments pagedComments = new PagedComments(List.of(), 0L, 0, 0, 0);
+        ViewCommentsFromTaskResponse expectedResponse = ViewCommentsFromTaskResponse.builder()
+            .content(List.of())
+            .totalElements(0L)
+            .totalPages(0)
+            .size(0)
+            .number(0)
+            .build();
+
+        given(commentRepository.findWithDetailsByTaskIdOrderByCreatedAt(taskId)).willReturn(parentComments);
+        given(commentRepository.findWithDetailByParentCommentIsInOrderByCreatedAt(parentComments))
+            .willReturn(childComments);
+        given(paginatorFactory.create(any(CommentPaginationData.class))).willReturn(mockPaginator);
+        given(mockPaginator.paginate(any())).willReturn(pagedComments);
+        given(commentMapper.toViewCommentsFromTaskResponse(pagedComments)).willReturn(expectedResponse);
+
+        // when
+        ViewCommentsFromTaskResponse result = viewCommentsFromTaskUseCase.execute(command);
+
+        // then
+        assertNotNull(result);
+        then(commentRepository).should(times(1)).findWithDetailsByTaskIdOrderByCreatedAt(taskId);
+    }
+}

--- a/src/test/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginatorTest.java
+++ b/src/test/java/indiv/abko/taskflow/domain/comment/util/HierarchicalCommentsPaginatorTest.java
@@ -1,0 +1,234 @@
+package indiv.abko.taskflow.domain.comment.util;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+import static org.mockito.Mockito.lenient;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import indiv.abko.taskflow.domain.comment.dto.CommentPaginationData;
+import indiv.abko.taskflow.domain.comment.entity.Comment;
+import indiv.abko.taskflow.domain.comment.util.HierarchicalCommentsPaginator.PagedComments;
+import indiv.abko.taskflow.domain.task.entity.Task;
+import indiv.abko.taskflow.domain.user.entity.Member;
+
+@ExtendWith(MockitoExtension.class)
+public class HierarchicalCommentsPaginatorTest {
+
+    @Mock
+    private Member mockMember;
+
+    @Mock
+    private Task mockTask;
+
+    @Test
+    @DisplayName("부모 댓글만 있을 때 정상적으로 페이지네이션한다")
+    void paginate_부모댓글만_있을때_성공() {
+        // given
+        Comment parent1 = createParentComment(1L, "부모 댓글 1");
+        Comment parent2 = createParentComment(2L, "부모 댓글 2");
+        Comment parent3 = createParentComment(3L, "부모 댓글 3");
+
+        List<Comment> parentComments = List.of(parent1, parent2, parent3);
+        List<Comment> childComments = List.of();
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = new HierarchicalCommentsPaginator(commentPaginationData);
+
+        Pageable pageable = PageRequest.of(0, 2);
+        PaginationContext paginationContext = new PaginationContext(pageable);
+
+        // when
+        PagedComments result = paginator.paginate(paginationContext);
+
+        // then
+        assertAll(
+            () -> assertEquals(2, result.comments().size()),
+            () -> assertEquals(parent1, result.comments().get(0)),
+            () -> assertEquals(parent2, result.comments().get(1)),
+            () -> assertEquals(3, result.totalElements()),
+            () -> assertEquals(2, result.totalPages()),
+            () -> assertEquals(2, result.size()),
+            () -> assertEquals(0, result.number()));
+    }
+
+    @Test
+    @DisplayName("부모 댓글과 자식 댓글이 있을 때 정상적으로 페이지네이션한다")
+    void paginate_부모댓글과_자식댓글이_있을때_성공() {
+        // given
+        Comment parent1 = createParentComment(1L, "부모 댓글 1");
+        Comment parent2 = createParentComment(2L, "부모 댓글 2");
+
+        Comment child1 = createChildComment(3L, "자식 댓글 1", parent1);
+        Comment child2 = createChildComment(4L, "자식 댓글 2", parent1);
+        Comment child3 = createChildComment(5L, "자식 댓글 3", parent2);
+
+        List<Comment> parentComments = List.of(parent1, parent2);
+        List<Comment> childComments = List.of(child1, child2, child3);
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = new HierarchicalCommentsPaginator(commentPaginationData);
+
+        Pageable pageable = PageRequest.of(0, 4);
+        PaginationContext paginationContext = new PaginationContext(pageable);
+
+        // when
+        PagedComments result = paginator.paginate(paginationContext);
+
+        // then
+        assertAll(
+            () -> assertEquals(4, result.comments().size()), // 페이지 크기 4에 맞춰 정확히 제한됨
+            () -> assertEquals(parent1, result.comments().get(0)),
+            () -> assertEquals(child1, result.comments().get(1)),
+            () -> assertEquals(child2, result.comments().get(2)),
+            () -> assertEquals(parent2, result.comments().get(3)), // parent2까지만 포함 (child3 제외)
+            () -> assertEquals(5, result.totalElements()),
+            () -> assertEquals(2, result.totalPages()), // Math.ceil(5.0 / 4.0) = 2
+            () -> assertEquals(4, result.size()),
+            () -> assertEquals(0, result.number()));
+    }
+
+    @Test
+    @DisplayName("페이지 크기에 맞춰 정확히 제한하여 페이지네이션한다")
+    void paginate_페이지크기_제한_성공() {
+        // given
+        Comment parent1 = createParentComment(1L, "부모 댓글 1");
+        Comment parent2 = createParentComment(2L, "부모 댓글 2");
+
+        Comment child1 = createChildComment(3L, "자식 댓글 1", parent1);
+        Comment child2 = createChildComment(4L, "자식 댓글 2", parent2);
+
+        List<Comment> parentComments = List.of(parent1, parent2);
+        List<Comment> childComments = List.of(child1, child2);
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = new HierarchicalCommentsPaginator(commentPaginationData);
+
+        Pageable pageable = PageRequest.of(0, 3);
+        PaginationContext paginationContext = new PaginationContext(pageable);
+
+        // when
+        PagedComments result = paginator.paginate(paginationContext);
+
+        // then
+        assertAll(
+            () -> assertEquals(3, result.comments().size()), // 페이지 크기 3에 맞춰 정확히 제한됨
+            () -> assertEquals(parent1, result.comments().get(0)),
+            () -> assertEquals(child1, result.comments().get(1)),
+            () -> assertEquals(parent2, result.comments().get(2)), // parent2까지만 포함 (child2 제외)
+            () -> assertEquals(4, result.totalElements()),
+            () -> assertEquals(2, result.totalPages()), // Math.ceil(4.0 / 3.0) = 2
+            () -> assertEquals(3, result.size()),
+            () -> assertEquals(0, result.number()));
+    }
+
+    @Test
+    @DisplayName("두 번째 페이지를 정상적으로 조회한다")
+    void paginate_두번째페이지_성공() {
+        // given
+        Comment parent1 = createParentComment(1L, "부모 댓글 1");
+        Comment parent2 = createParentComment(2L, "부모 댓글 2");
+        Comment parent3 = createParentComment(3L, "부모 댓글 3");
+
+        List<Comment> parentComments = List.of(parent1, parent2, parent3);
+        List<Comment> childComments = List.of();
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = new HierarchicalCommentsPaginator(commentPaginationData);
+
+        Pageable pageable = PageRequest.of(1, 2);
+        PaginationContext paginationContext = new PaginationContext(pageable);
+
+        // when
+        PagedComments result = paginator.paginate(paginationContext);
+
+        // then
+        assertAll(
+            () -> assertEquals(1, result.comments().size()),
+            () -> assertEquals(parent3, result.comments().get(0)),
+            () -> assertEquals(3, result.totalElements()),
+            () -> assertEquals(2, result.totalPages()),
+            () -> assertEquals(1, result.size()),
+            () -> assertEquals(1, result.number()));
+    }
+
+    @Test
+    @DisplayName("빈 데이터일 때 빈 결과를 반환한다")
+    void paginate_빈데이터_성공() {
+        // given
+        List<Comment> parentComments = List.of();
+        List<Comment> childComments = List.of();
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = new HierarchicalCommentsPaginator(commentPaginationData);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        PaginationContext paginationContext = new PaginationContext(pageable);
+
+        // when
+        PagedComments result = paginator.paginate(paginationContext);
+
+        // then
+        assertAll(
+            () -> assertTrue(result.comments().isEmpty()),
+            () -> assertEquals(0, result.totalElements()),
+            () -> assertEquals(0, result.totalPages()),
+            () -> assertEquals(0, result.size()),
+            () -> assertEquals(0, result.number()));
+    }
+
+    @Test
+    @DisplayName("자식 댓글이 없는 부모 댓글이 있을 때 정상적으로 처리한다")
+    void paginate_자식댓글없는_부모댓글_성공() {
+        // given
+        Comment parent1 = createParentComment(1L, "부모 댓글 1");
+        Comment parent2 = createParentComment(2L, "부모 댓글 2");
+
+        Comment child1 = createChildComment(3L, "자식 댓글 1", parent1);
+        // parent2는 자식 댓글이 없음
+
+        List<Comment> parentComments = List.of(parent1, parent2);
+        List<Comment> childComments = List.of(child1);
+
+        CommentPaginationData commentPaginationData = new CommentPaginationData(parentComments, childComments);
+        HierarchicalCommentsPaginator paginator = new HierarchicalCommentsPaginator(commentPaginationData);
+
+        Pageable pageable = PageRequest.of(0, 10);
+        PaginationContext paginationContext = new PaginationContext(pageable);
+
+        // when
+        PagedComments result = paginator.paginate(paginationContext);
+
+        // then
+        assertAll(
+            () -> assertEquals(3, result.comments().size()),
+            () -> assertEquals(parent1, result.comments().get(0)),
+            () -> assertEquals(child1, result.comments().get(1)),
+            () -> assertEquals(parent2, result.comments().get(2)),
+            () -> assertEquals(3, result.totalElements()),
+            () -> assertEquals(1, result.totalPages()),
+            () -> assertEquals(3, result.size()),
+            () -> assertEquals(0, result.number()));
+    }
+
+    private Comment createParentComment(Long id, String content) {
+        Comment comment = mock(Comment.class);
+        // getId()는 자식 댓글이 있는 경우에만 호출되므로 lenient로 설정
+        lenient().when(comment.getId()).thenReturn(id);
+        return comment;
+    }
+
+    private Comment createChildComment(Long id, String content, Comment parent) {
+        Comment comment = mock(Comment.class);
+        given(comment.getParentComment()).willReturn(parent);
+        return comment;
+    }
+}


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- #44 
- 사용자가 Task에 작성한 댓글을 적절하게 조회할 수 있는 기능을 구현하였습니다.

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- 엔드 포인트 추가.
- 비즈니스 로직 구현.
- 테스트 완료.

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->