### PR TITLE
feat: Spring security 인가 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ out/
 
 ### application ymls ###
 application-*.yml
+!application-test.yml

--- a/src/main/java/indiv/abko/taskflow/domain/auth/annotation/IsAdmin.java
+++ b/src/main/java/indiv/abko/taskflow/domain/auth/annotation/IsAdmin.java
@@ -1,0 +1,14 @@
+package indiv.abko.taskflow.domain.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@PreAuthorize("hasRole('ADMIN')")
+public @interface IsAdmin {
+}

--- a/src/main/java/indiv/abko/taskflow/domain/auth/exception/AuthErrorCode.java
+++ b/src/main/java/indiv/abko/taskflow/domain/auth/exception/AuthErrorCode.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
+	FORBIDDEN(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
 	INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 	AUTHENTICATION_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패했습니다."),
 	PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),

--- a/src/main/java/indiv/abko/taskflow/domain/team/controller/TeamController.java
+++ b/src/main/java/indiv/abko/taskflow/domain/team/controller/TeamController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+import indiv.abko.taskflow.domain.auth.annotation.IsAdmin;
 import indiv.abko.taskflow.domain.team.dto.request.AddTeamMemberRequest;
 import indiv.abko.taskflow.domain.team.dto.request.CreateTeamRequest;
 import indiv.abko.taskflow.domain.team.dto.request.UpdateTeamRequest;
@@ -45,6 +46,7 @@ public class TeamController {
 	private final DeleteTeamMemberUseCase deleteTeamMemberUseCase;
 
 	// 팀 생성
+	@IsAdmin
 	@PostMapping("/api/teams")
 	@ResponseStatus(HttpStatus.CREATED)
 	public CommonResponse<CreateTeamResponse> createTeam(
@@ -77,6 +79,7 @@ public class TeamController {
 	}
 
 	// 팀 수정
+	@IsAdmin
 	@PutMapping("/api/teams/{teamId}")
 	public CommonResponse<UpdateTeamResponse> updateTeam(
 		@Valid @RequestBody UpdateTeamRequest updateTeamRequest,
@@ -91,6 +94,7 @@ public class TeamController {
 	}
 
 	// 팀 삭제
+	@IsAdmin
 	@DeleteMapping("/api/teams/{teamId}")
 	public CommonResponse<Void> deleteTeam(
 		@PathVariable Long teamId
@@ -101,6 +105,7 @@ public class TeamController {
 	}
 
 	// 팀 멤버 추가
+	@IsAdmin
 	@PostMapping("/api/teams/{teamId}/members")
 	public CommonResponse<AddTeamMemberResponse> createTeamMember(
 		@Valid @RequestBody AddTeamMemberRequest addTeamMemberRequest,
@@ -114,6 +119,7 @@ public class TeamController {
 	}
 
 	// 팀 멤버 제거
+	@IsAdmin
 	@DeleteMapping("/api/teams/{teamId}/members/{userId}")
 	public CommonResponse<DeleteTeamMemberResponse> deleteTeamMember(
 		@PathVariable Long teamId,

--- a/src/main/java/indiv/abko/taskflow/global/config/SecurityConfig.java
+++ b/src/main/java/indiv/abko/taskflow/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -30,6 +31,7 @@ import lombok.RequiredArgsConstructor;
 
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
@@ -45,15 +47,17 @@ public class SecurityConfig {
 			.cors(Customizer.withDefaults())
 			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 			.authorizeHttpRequests(auth -> auth
+				// OPTIONS 요청은 CORS pre-flight를 위해 항상 허용
 				.requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-				.requestMatchers("/api/auth/register").permitAll()
-				.requestMatchers("/api/auth/login").permitAll()
+				.requestMatchers("/api/auth/**").permitAll()
 				.anyRequest().authenticated()
 			)
 			.oauth2ResourceServer(oauth2 -> oauth2
 				.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter))
 			)
-			.exceptionHandling(handler -> handler.authenticationEntryPoint(customAuthenticationEntryPoint))
+			.exceptionHandling(handler -> handler
+				.authenticationEntryPoint(customAuthenticationEntryPoint) // 401
+			)
 			.addFilterBefore(jwtBlacklistFilter, BearerTokenAuthenticationFilter.class);
 
 		return http.build();

--- a/src/main/java/indiv/abko/taskflow/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/indiv/abko/taskflow/global/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
@@ -94,6 +95,14 @@ public class GlobalExceptionHandler {
 		String message = String.format("지원되지 않는 HTTP 메서드입니다: %s. 허용된 메서드: %s", method, supported);
 		Map<String, String> errors = Map.of("method", message);
 		return new ResponseEntity<>(CommonResponse.failure("잘못된 요청입니다.", errors), HttpStatus.METHOD_NOT_ALLOWED);
+	}
+
+	@ExceptionHandler(AccessDeniedException.class)
+	public ResponseEntity<CommonResponse<?>> handleAccessDeniedException(AccessDeniedException ex) {
+		ErrorCode errorCode = AuthErrorCode.FORBIDDEN;
+		HttpStatus status = errorCode.getHttpStatus();
+		String message = errorCode.getMessage();
+		return new ResponseEntity<>(CommonResponse.failure(message, null), status);
 	}
 
 	@ExceptionHandler(Exception.class)

--- a/src/test/java/indiv/abko/taskflow/integration/TeamApiIntegrationTest.java
+++ b/src/test/java/indiv/abko/taskflow/integration/TeamApiIntegrationTest.java
@@ -1,0 +1,77 @@
+package indiv.abko.taskflow.integration;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.ActiveProfiles;
+
+import indiv.abko.taskflow.domain.user.entity.UserRole;
+import indiv.abko.taskflow.global.jwt.JwtUtil;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+public class TeamApiIntegrationTest {
+
+	@Autowired
+	private TestRestTemplate restTemplate;
+
+	@Autowired
+	private JwtUtil jwtUtil;
+
+	@Nested
+	class CreateTeam {
+
+		@Test
+		void ADMIN_역할은_팀_생성에_성공한다() {
+			// given
+			String adminToken = jwtUtil.createAccessToken(1L, UserRole.ADMIN);
+			HttpHeaders headers = new HttpHeaders();
+			headers.setBearerAuth(adminToken);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+
+			Map<String, String> requestBody = Map.of(
+				"name", "Test team name",
+				"description", "Test team description"
+			);
+			HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+			// when
+			ResponseEntity<Void> response = restTemplate.postForEntity("/api/teams", requestEntity, Void.class);
+
+			// then
+			assertThat(response.getStatusCode()).isIn(HttpStatus.CREATED, HttpStatus.OK);
+		}
+
+		@Test
+		void USER_역할은_팀_생성_권한이_없어_실패한다() {
+			// given
+			String userToken = jwtUtil.createAccessToken(1L, UserRole.USER);
+			HttpHeaders headers = new HttpHeaders();
+			headers.setBearerAuth(userToken);
+			headers.setContentType(MediaType.APPLICATION_JSON);
+
+			Map<String, String> requestBody = Map.of(
+				"name", "Test team name",
+				"description", "Test team description"
+			);
+			HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(requestBody, headers);
+
+			// when
+			ResponseEntity<Void> response = restTemplate.postForEntity("/api/teams", requestEntity, Void.class);
+
+			// then
+			assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+		}
+	}
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,13 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+
+jwt:
+  issuer: taskflow
+  secret: 9da94bab9824a466ae237b291ce1be9f5d2a5d166079b26992b3cbd356eba561
+  access-token-validity-seconds: 3600


### PR DESCRIPTION
## 📝 개요
<!-- 이 PR이 왜 필요한지 간단하게 설명해주세요. (관련 이슈가 있다면 태그해주세요) -->
- 관리자만 접근할 수 있는 API 인가 설정 (인가 실패 시 403 FORBIDDEN 반환)
- 적용하고자 하는 Controller의 타입 및 메서드에 `@IsAdmin` 어노테이션을 붙여 처리할 수 있도록 구현
- close #89 

## 💻 작업 내용
<!-- 변경된 내용을 간결하게 나열해주세요. -->
- API 인가 설정
- `Team` 도메인의 `createTeam` 팀 생성 API를 기준으로 인가 관련 통합테스트 코드 작성

## 🖼️ 스크린샷 (optional)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요. -->